### PR TITLE
Add Altair package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,4 +240,4 @@ RUN pip install --upgrade mpld3 && \
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \
     # Required to display Altair charts in Jupyter notebook
-    jupyter nbextension install --py vega
+    jupyter nbextension install --user --py vega

--- a/Dockerfile
+++ b/Dockerfile
@@ -235,6 +235,9 @@ RUN pip install --upgrade mpld3 && \
     pip install git+https://github.com/fmfn/BayesianOptimization.git && \
     pip install matplotlib-venn && \
     pip install git+git://github.com/rasbt/mlxtend.git#egg=mlxtend && \
+    pip install altair && \
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
-    rm -rf /root/.cache/pip/*
+    rm -rf /root/.cache/pip/* && \
+    # Required to display Altair charts in Jupyter notebook
+    jupyter nbextension install --py vega


### PR DESCRIPTION
This PR adds two lines to the `Dockerfile`:

- `pip install altair`
- `jupyter nbextension install --py vega` to activate the Vega extension. This makes it possible to display Vega charts in the Jupyter notebook.

[Altair](https://altair-viz.github.io/) is a Python frontend for [Vega-Lite](https://vega.github.io/vega-lite/), and it integrates with Pandas out of the box. Its declarative syntax makes it very easy to create complex charts and that's why I'm proposing its addition.