### PR TITLE
ImageHash library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -256,6 +256,7 @@ RUN pip install --upgrade mpld3 && \
     pip install git+git://github.com/rasbt/mlxtend.git#egg=mlxtend && \
     pip install altair && \
     pip install pystan && \
+    pip install ImageHash && \
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \


### PR DESCRIPTION
adding https://pypi.python.org/pypi/ImageHash
checked that after pip install in the image one can import imagehash