### PR TITLE
Adding SimpleITK Conda Package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -290,6 +290,7 @@ RUN pip install --upgrade mpld3 && \
     pip install pyflux && \
     pip install terminalplot && \
     pip install pydicom && \
+    conda install --channel https://conda.anaconda.org/SimpleITK --quiet --yes 'SimpleITK=0.10.0' && \
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \


### PR DESCRIPTION
adding SimpleITK for processing and handling DICOM volumes (addressing issue https://github.com/Kaggle/docker-python/issues/57) and required for the tutorial for the DSB (https://github.com/booz-allen-hamilton/DSB3Tutorial)