### PR TITLE
Update Dockerfile with Facebook Prophet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -306,6 +306,7 @@ RUN pip install --upgrade mpld3 && \
     pip install python-louvain && \
     pip install pyexcel-ods && \
     pip install sklearn-pandas && \
+    pip install fbprophet && \
     conda install -y -c conda-forge -c ioam holoviews && \
     pip install git+https://github.com/ioam/geoviews.git && \
     ##### ^^^^ Add new contributions above here


### PR DESCRIPTION
Add `fbprophet` as package installed in Kaggle Docker image. More info on Prophet, which was open-sourced last week: https://facebookincubator.github.io/prophet/