### PR TITLE
Add the py_stringsimjoin package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -312,6 +312,7 @@ RUN pip install --upgrade mpld3 && \
     pip install git+https://github.com/ioam/geoviews.git && \
     pip install hypertools && \
     pip install nxviz && \
+    pip install py_stringsimjoin && \
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \


### PR DESCRIPTION
This adds a new package for performing fast joins based on string similarity. The package is well-tested and maintained by the researchers in University of Wisconsin-Madison. Here is a link to their [project](https://sites.google.com/site/anhaidgroup/projects/magellan/py_stringsimjoin).