### PR TITLE
add spectral library for multi/hyper spectral images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -286,6 +286,7 @@ RUN pip install --upgrade mpld3 && \
     pip install git+https://github.com/hammerlab/fancyimpute.git && \
     pip install git+https://github.com/pymc-devs/pymc3 && \
     pip install tifffile && \
+    pip install spectral && \
     pip install descartes && \
     pip install geojson && \
     pip install pysal && \


### PR DESCRIPTION
"Spectral Python (SPy) is a pure Python module for processing hyperspectral image data."

It's very useful for viewing multispectral data that doesn't look like "normal" rgb images with standard 8-bit values.

Very simple dependencies: numpy, pillow and matplotlib (all already installed)
http://www.spectralpython.net/installation.html