### PR TITLE
Patch tornado for .NET websocket compatibility.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM continuumio/anaconda3:latest
 
 ADD cache_keras_weights.py /usr/local/src/cache_keras_weights.py
+ADD patches/ /tmp/patches/
 
     # Use a fixed apt-get repo to stop intermittent failures due to flaky httpredir connections,
     # as described by Lionel Chan at http://stackoverflow.com/a/37426929/5881346
@@ -319,9 +320,13 @@ RUN pip install --upgrade mpld3 && \
     pip install mlens && \
     pip install scikit-multilearn && \
     pip install -e git+http://github.com/tensorflow/cleverhans.git#egg=cleverhans && \
-  
+
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \
     # Required to display Altair charts in Jupyter notebook
     jupyter nbextension install --user --py vega
+
+# Finally, apply any locally defined patches.
+RUN /bin/bash -c \
+    "cd / && for p in $(ls /tmp/patches/*.patch); do echo '= Applying patch '\${p}; patch -p2 < \${p}; done"

--- a/patches/tornado-fix-issue-2097.patch
+++ b/patches/tornado-fix-issue-2097.patch
@@ -1,0 +1,27 @@
+diff -Naur /base/opt/conda/pkgs/tornado-4.5.1-py36_0/lib/python3.6/site-packages/tornado/http1connection.py /patched/opt.new/conda/lib/python3.6/site-packages/tornado/http1connection.py
+--- /base/opt/conda/lib/python3.6/site-packages/tornado/http1connection.py 2017-04-16 23:47:57.000000000 +0000
++++ /patched/opt.new/conda/lib/python3.6/site-packages/tornado/http1connection.py     2017-06-28 21:18:59.902402220 +0000
+@@ -349,6 +349,11 @@
+                 # self._request_start_line.version or
+                 # start_line.version?
+                 self._request_start_line.version == 'HTTP/1.1' and
++                # 1xx, 204 and 304 responses have no body (not even a zero-length
++                # body), and so should not have either Content-Length or
++                # Transfer-Encoding headers.
++                start_line.code not in (204, 304) and
++                (start_line.code < 100 or start_line.code >= 200) and
+                 # 304 responses have no body (not even a zero-length body), and so
+                 # should not have either Content-Length or Transfer-Encoding.
+                 # headers.
+diff -Naur /base/opt/conda/lib/python3.6/site-packages/tornado/web.py /patched/opt.new/conda/lib/python3.6/site-packages/tornado/web.py
+--- /base/opt/conda/lib/python3.6/site-packages/tornado/web.py     2017-06-28 21:22:56.505186743 +0000
++++ /patched/opt.new/conda/lib/python3.6/site-packages/tornado/web.py 2017-06-28 21:22:48.421228255 +0000
+@@ -977,7 +977,8 @@
+             if self._status_code in (204, 304):
+                 assert not self._write_buffer, "Cannot send body with %s" % self._status_code
+                 self._clear_headers_for_304()
+-            elif "Content-Length" not in self._headers:
++            elif ("Content-Length" not in self._headers and
++                  (self._status_code < 100 or self._status_code >= 200)):
+                 content_length = sum(len(part) for part in self._write_buffer)
+                 self.set_header("Content-Length", content_length)


### PR DESCRIPTION
This adds a generic patching mechanism to `kaggle/python` and a single patch
to apply the equivalent of https://github.com/tornadoweb/tornado/pull/2098 so
we don't have to wait for the upstream change to trickle down.

Resulting image has been verified to prevent kaggle websockets to be broken off
every 100s.