### PR TITLE
add paramnb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -321,7 +321,8 @@ RUN pip install --upgrade mpld3 && \
     pip install leven && \
     pip install catboost && \
     pip install mlbox && \
-
+    pip install paramnb && \
+    
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \


### PR DESCRIPTION
Add the Python library `paramnb` to Dockerfile. To enable running [a notebook](https://github.com/bokeh/datashader/blob/master/examples/nyc_taxi-paramnb.ipynb) relating to interactive visualization for NYC Taxi with datashader.