### PR TITLE
dipy package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -323,6 +323,7 @@ RUN pip install --upgrade mpld3 && \
     pip install mlbox && \
     pip install paramnb && \
     pip install folium && \
+    pip install dipy && \
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \


### PR DESCRIPTION
DIPY is a python package used for brain image analysis such as MRI data (2D and 3D). Would be really useful for many competitions.