### PR TITLE
Add hallucinate - a lightweight library for quick ML experimentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -325,6 +325,7 @@ RUN pip install --upgrade mpld3 && \
     pip install folium && \
     pip install scikit-plot && \
     pip install dipy && \
+    pip install git+https://github.com/dvaida/hallucinate.git && \
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \


### PR DESCRIPTION
Here's a glimpse of what it does, highly dynamic at the moment, changing/adding stuff on a daily basis: https://github.com/dvaida/hallucinate/blob/master/Teaser.ipynb BTW, the reason I submitted this as a pull request is a 'reverse engineering' kernel (that I cannot run w/o hallucinate) on the Titanic Survivors proving some realistic scores on the dataset, how you can get almost 83% on the pub LB but still with a 79 - 80% score on the "real" dataset - hence the reverse engineering part, I used it to learn/validate the training scores and show how the LB can be misleading rather than submit a 1. accuracy score ;-)