### PR TITLE
pip install nibabel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -240,6 +240,7 @@ RUN pip install --upgrade mpld3 && \
     pip install gpxpy && \
     pip install arrow && \
     pip install vtk && \
+    pip install nibabel && \
     pip install pronouncing && \
     pip install markovify && \
     pip install sexmachine  && \


### PR DESCRIPTION
pip install nibabel

the nibabel library supports reading and writing of neuroimaging data formats.