### PR TITLE
Adding the pykoko package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -359,6 +359,7 @@ RUN pip install --upgrade mpld3 && \
     pip install google-cloud-bigquery && \
     pip install ortools && \
     pip install scattertext && \
+    pip install pykoko && \
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \


### PR DESCRIPTION
Koko is a light-weight tool for extracting patterns from text. The previous build of Koko could not be included in Kaggle Docker as it used Spacy1.9.0. The current version is compatible with Spacy 2.0.2 (which is running on Kaggle). Many thanks for considering this.
