### PR TITLE
Add wfdb to pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -376,6 +376,7 @@ RUN pip install --upgrade mpld3 && \
     pip install emoji && \
     # Add Japanese morphological analysis engine
     pip install janome && \
+    pip install wfdb && \ # Read data from physionet
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \


### PR DESCRIPTION
There are many datasets in the [physionet physiobank database](https://www.physionet.org/physiobank/) with physiologic signals and related data for use by the biomedical research community.

Some data has already been uploaded to kaggle data sets but it's hard to use because it is not in the right format:
https://www.kaggle.com/ecerulm/apneaecg/discussion/33856

By adding the [wfdb](https://www.physionet.org/physiotools/wfdb.shtml) package to the kernels it will allow users to explore this data set and more. There are lots of really interesting machine learning challenges in these data sets.

Fixes #163