### PR TITLE
Add yellowbrick: a machine learning visualization library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -383,6 +383,8 @@ RUN pip install --upgrade mpld3 && \
     pip install wfdb && \
     pip install vecstack && \
     pip install sklearn-contrib-lightning && \
+    # yellowbrick machine learning visualization library
+    pip install yellowbrick && \
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \
@@ -417,6 +419,3 @@ ENV MPLBACKEND "agg"
 # Finally, apply any locally defined patches.
 RUN /bin/bash -c \
     "cd / && for p in $(ls /tmp/patches/*.patch); do echo '= Applying patch '\${p}; patch -p2 < \${p}; done"
-    
-
-


### PR DESCRIPTION
Adding yellowbrick to the dockerfile so that folks on kaggle can use this library.

From our documentation at http://www.scikit-yb.org/en/latest/:
> Yellowbrick is a suite of visual diagnostic tools called “Visualizers” that extend the Scikit-Learn API to allow human steering of the model selection process. In a nutshell, Yellowbrick combines Scikit-Learn with Matplotlib in the best tradition of the Scikit-Learn documentation, but to produce visualizations for your models! 