### PR TITLE
Unpin MxNet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -166,7 +166,7 @@ RUN apt-get update && \
     cd /usr/local/src && git clone https://github.com/SciTools/cartopy.git && \
     cd cartopy && python setup.py install && \
     # MXNet
-    pip install mxnet==0.11.0 && \
+    pip install mxnet && \
     # h2o
     # This requires python-software-properties and Java, which were installed above.
     cd /usr/local/src && mkdir h2o && cd h2o && \

--- a/test_build.py
+++ b/test_build.py
@@ -86,6 +86,10 @@ print("pyfasttext ok")
 import fastText
 print("fastText ok")
 
+import mxnet
+import mxnet.gluon
+print("mxnet ok")
+
 import os
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer


### PR DESCRIPTION
This unpins mxnet version. It was build from source before, and then moved to pip install in 6c4cac180ced8b0712e3cd3b34adac19f6daaa46.

I verified that package is installed correctly by building the docker image locally. Here is the relevant part of the build log where the package is installed:
```
Collecting mxnet
  Downloading mxnet-1.0.0.post4-py2.py3-none-manylinux1_x86_64.whl (27.4MB)
Requirement already satisfied: requests==2.18.4 in /opt/conda/lib/python3.6/site-packages (from mxnet)
Collecting graphviz==0.8.1 (from mxnet)
  Downloading graphviz-0.8.1-py2.py3-none-any.whl
Requirement already satisfied: numpy<=1.13.3 in /opt/conda/lib/python3.6/site-packages (from mxnet)
Requirement already satisfied: chardet<3.1.0,>=3.0.2 in /opt/conda/lib/python3.6/site-packages (from requests==2.18.4->mxnet)
Requirement already satisfied: idna<2.7,>=2.5 in /opt/conda/lib/python3.6/site-packages (from requests==2.18.4->mxnet)
Requirement already satisfied: urllib3<1.23,>=1.21.1 in /opt/conda/lib/python3.6/site-packages (from requests==2.18.4->mxnet)
Requirement already satisfied: certifi>=2017.4.17 in /opt/conda/lib/python3.6/site-packages (from requests==2.18.4->mxnet)
Installing collected packages: graphviz, mxnet
Successfully installed graphviz-0.8.1 mxnet-1.0.0.post4
```

and other major libraries seems to be fine as well.