### PR TITLE
NVidia cuda support.

### DIFF
--- a/test_build.py
+++ b/test_build.py
@@ -86,6 +86,10 @@ print("pyfasttext ok")
 import fastText
 print("fastText ok")
 
+import pycuda
+print("pycuda ok")
+
+# bigquery proxy
 import os
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer


### PR DESCRIPTION
This adds the initial support for the current GPUs in GCP.

I have only verified that pycuda can access a single k80 so far. Other
libraries may not work yet.  I suppose prebuild ones may or not have it,
and built-from-source ones should include support from the presence of
the cuda dev package.

The resulting image should work fine on GPU-less hosts as well.