### PR TITLE
Update PyTorch conda channel from `soumith` to `pytorch`?

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,7 +221,7 @@ RUN apt-get update && \
     #./waf configure --mode=release --build-static --with-python --with-cpptests --with-examples --with-vamp && \
     #./waf && ./waf install && mv /usr/local/lib/python3.6/site-packages/essentia /opt/conda/lib/python3.6 && \
     # PyTorch
-    conda install -y pytorch torchvision -c soumith && \
+    conda install -y pytorch torchvision -c pytorch && \
     # PyTorch Audio
     apt-get install -y sox libsox-dev libsox-fmt-all && \
     pip install cffi && \


### PR DESCRIPTION
This is more of a question than a recommendation.  According to [the PyTorch homepage](http://pytorch.org), it looks like it's now recommended to install PyTorch from the conda channel `pytorch`, rather than `soumith`:

<img width="539" alt="screen shot 2018-01-26 at 9 38 55 am" src="https://user-images.githubusercontent.com/185923/35450302-d5acebec-027c-11e8-8ab4-54ea29781420.png">

And if we compare the channel versions, it looks like [`soumith/pytorch` is on v0.2](https://anaconda.org/soumith/pytorch) and was [last updated 4-5 months ago](https://anaconda.org/soumith/pytorch/files), whereas [`pytorch/pytorch` is on v0.3](https://anaconda.org/pytorch/pytorch) and was [last updated 1-2 months ago](https://anaconda.org/pytorch/pytorch/files).

I'm not sure of any official stance on this, other than the project homepage, and I also don't have enough background with this repo to know why it's currently using `soumith`, but it does appear to be an outdated usage.