### PR TITLE
pip install featuretools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -399,6 +399,9 @@ RUN pip install flashtext && \
     pip install marisa-trie && \
     pip install pyemd && \
     pip install pyupset && \
+    pip install pympler && \
+    pip install s3fs && \
+    pip install featuretools && \
     pip install -e git+https://github.com/SohierDane/BigQuery_Helper#egg=bq_helper && \
     ##### ^^^^ Add new contributions above here
     # clean up pip cache


### PR DESCRIPTION
[Featuretools](www.featuretools.com) is a library for feature engineering that is compatible with pandas and sklearn. It can be found on [github](https://github.com/featuretools/featuretools).

This is a follow up from #154 where a version requirement was overwriting numpy. As discussed with @nerdcha we have relaxed that requirement which seems to resolve the issue. I've also added a 
`pip install pympler` and `pip install s3fs` following the conversation there. The full output from the install can be found below.

```
Status: Downloaded newer image for kaggle/python:latest
root@215a35d7f988:/# pip install pympler
Collecting pympler
  Downloading Pympler-0.5.tar.gz (170kB)
    100% |████████████████████████████████| 174kB 2.2MB/s 
Building wheels for collected packages: pympler
  Running setup.py bdist_wheel for pympler ... done
  Stored in directory: /root/.cache/pip/wheels/57/c6/8b/91d4e0ffb106e935ca145964d13c03619943430ba9344c0206
Successfully built pympler
Installing collected packages: pympler
Successfully installed pympler-0.5
root@215a35d7f988:/# pip install s3fs
Collecting s3fs
  Downloading s3fs-0.1.3-py2.py3-none-any.whl
Requirement already satisfied: boto3 in /opt/conda/lib/python3.6/site-packages (from s3fs)
Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /opt/conda/lib/python3.6/site-packages (from boto3->s3fs)
Requirement already satisfied: botocore<1.9.0,>=1.8.36 in /opt/conda/lib/python3.6/site-packages (from boto3->s3fs)
Requirement already satisfied: s3transfer<0.2.0,>=0.1.10 in /opt/conda/lib/python3.6/site-packages (from boto3->s3fs)
Requirement already satisfied: docutils>=0.10 in /opt/conda/lib/python3.6/site-packages (from botocore<1.9.0,>=1.8.36->boto3->s3fs)
Requirement already satisfied: python-dateutil<3.0.0,>=2.1 in /opt/conda/lib/python3.6/site-packages (from botocore<1.9.0,>=1.8.36->boto3->s3fs)
Requirement already satisfied: six>=1.5 in /opt/conda/lib/python3.6/site-packages (from python-dateutil<3.0.0,>=2.1->botocore<1.9.0,>=1.8.36->boto3->s3fs)
Installing collected packages: s3fs
Successfully installed s3fs-0.1.3
root@215a35d7f988:/# pip install featuretools
Collecting featuretools
  Downloading featuretools-0.1.18.tar.gz (128kB)
    100% |████████████████████████████████| 133kB 2.1MB/s 
Requirement already satisfied: numpy>=1.13.3 in /opt/conda/lib/python3.6/site-packages (from featuretools)
Requirement already satisfied: scipy>=1.0.0 in /opt/conda/lib/python3.6/site-packages (from featuretools)
Requirement already satisfied: pandas>=0.20.3 in /opt/conda/lib/python3.6/site-packages (from featuretools)
Requirement already satisfied: s3fs>=0.1.2 in /opt/conda/lib/python3.6/site-packages (from featuretools)
Requirement already satisfied: tqdm>=4.19.2 in /opt/conda/lib/python3.6/site-packages (from featuretools)
Requirement already satisfied: toolz>=0.8.2 in /opt/conda/lib/python3.6/site-packages (from featuretools)
Requirement already satisfied: pyyaml>=3.12 in /opt/conda/lib/python3.6/site-packages (from featuretools)
Requirement already satisfied: cloudpickle>=0.4.0 in /opt/conda/lib/python3.6/site-packages (from featuretools)
Requirement already satisfied: future>=0.16.0 in /opt/conda/lib/python3.6/site-packages (from featuretools)
Requirement already satisfied: pympler>=0.5 in /opt/conda/lib/python3.6/site-packages (from featuretools)
Requirement already satisfied: python-dateutil>=2 in /opt/conda/lib/python3.6/site-packages (from pandas>=0.20.3->featuretools)
Requirement already satisfied: pytz>=2011k in /opt/conda/lib/python3.6/site-packages (from pandas>=0.20.3->featuretools)
Requirement already satisfied: boto3 in /opt/conda/lib/python3.6/site-packages (from s3fs>=0.1.2->featuretools)
Requirement already satisfied: six>=1.5 in /opt/conda/lib/python3.6/site-packages (from python-dateutil>=2->pandas>=0.20.3->featuretools)
Requirement already satisfied: s3transfer<0.2.0,>=0.1.10 in /opt/conda/lib/python3.6/site-packages (from boto3->s3fs>=0.1.2->featuretools)
Requirement already satisfied: jmespath<1.0.0,>=0.7.1 in /opt/conda/lib/python3.6/site-packages (from boto3->s3fs>=0.1.2->featuretools)
Requirement already satisfied: botocore<1.9.0,>=1.8.36 in /opt/conda/lib/python3.6/site-packages (from boto3->s3fs>=0.1.2->featuretools)
Requirement already satisfied: docutils>=0.10 in /opt/conda/lib/python3.6/site-packages (from botocore<1.9.0,>=1.8.36->boto3->s3fs>=0.1.2->featuretools)
Building wheels for collected packages: featuretools
  Running setup.py bdist_wheel for featuretools ... done
  Stored in directory: /root/.cache/pip/wheels/33/a9/9e/d1d7629d745c98b7df4b3a5011f439cd2aa3e5f27e078a1181
Successfully built featuretools
Installing collected packages: featuretools
Successfully installed featuretools-0.1.18
root@215a35d7f988:/# 
```