### PR TITLE
Workaround for PyTorch issue 2575

### DIFF
--- a/patches/sitecustomize.py
+++ b/patches/sitecustomize.py
@@ -1,4 +1,8 @@
 # Monkey patches BigQuery client creation to use proxy.
+
+# Import torch before anything else. This is a hacky workaround to an error on dlopen
+# reporting a limit on static TLS, tracked in https://github.com/pytorch/pytorch/issues/2575
+import torch
 import os
 
 kaggle_proxy_token = os.getenv("KAGGLE_DATA_PROXY_TOKEN")

--- a/test_build.py
+++ b/test_build.py
@@ -96,6 +96,20 @@ print("bokeh ok")
 import seaborn
 print("seaborn ok")
 
+# PyTorch smoke test based on http://pytorch.org/tutorials/beginner/nlp/deep_learning_tutorial.html
+import torch
+import torch.nn as tnn
+import torch.autograd as autograd
+torch.manual_seed(31337)
+linear_torch = tnn.Linear(5,3)
+data_torch = autograd.Variable(torch.randn(2, 5))
+print(linear_torch(data_torch))
+print("PyTorch ok")
+
+import fastai
+from fastai.io import get_data
+print("fast.ai ok")
+
 import os
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer


### PR DESCRIPTION
This patch will allow Kaggle users to use PyTorch and fast.ai once again. They are currently broken in kernels due to an underlying problem with Torch's treatment of static TLS, documented in https://github.com/pytorch/pytorch/issues/2575. Our users have reported the issue in https://github.com/Kaggle/docker-python/issues/157 and https://github.com/Kaggle/docker-python/issues/166.