### PR TITLE
Add pandasql to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -386,6 +386,8 @@ RUN pip install --upgrade mpld3 && \
     # yellowbrick machine learning visualization library
     pip install yellowbrick && \
     pip install mlcrate && \
+    # pandasql - query pandas dataframes using sql syntax
+    pip install pandasql && \
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \
     # Required to display Altair charts in Jupyter notebook
@@ -452,7 +454,7 @@ RUN pip install bcolz && \
     # clean up pip cache
     rm -rf /root/.cache/pip/* && \
     cd && rm -rf /usr/local/src/*
-    
+
     ###########
     #
     #      NEW CONTRIBUTORS:


### PR DESCRIPTION
Add pandasql to Dockerfile

Successfully tested pip command on current master docker image:

$: pip install pandasql 
Collecting pandasql
  Downloading pandasql-0.7.3.tar.gz
Requirement already satisfied: numpy in /opt/conda/lib/python3.6/site-packages (from pandasql)
Requirement already satisfied: pandas in /opt/conda/lib/python3.6/site-packages (from pandasql)
Requirement already satisfied: sqlalchemy in /opt/conda/lib/python3.6/site-packages (from pandasql)
Requirement already satisfied: pytz>=2011k in /opt/conda/lib/python3.6/site-packages (from pandas->pandasql)
Requirement already satisfied: python-dateutil>=2 in /opt/conda/lib/python3.6/site-packages (from pandas->pandasql)
Requirement already satisfied: six>=1.5 in /opt/conda/lib/python3.6/site-packages (from python-dateutil>=2->pandas->pandasql)
Building wheels for collected packages: pandasql
  Running setup.py bdist_wheel for pandasql ... done
  Stored in directory: /root/.cache/pip/wheels/a4/4b/e6/88a009d13e4b64f7292e802a93d19619cceb135ba599235430
Successfully built pandasql
Installing collected packages: pandasql
Successfully installed pandasql-0.7.3