### PR TITLE
Add shap to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -467,6 +467,7 @@ RUN pip install flashtext && \
     pip install -e git+https://github.com/SohierDane/BigQuery_Helper#egg=bq_helper && \
     pip install hpsklearn && \
     pip install git+https://github.com/Kaggle/learntools && \
+    pip install shap && \
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/*

--- a/test_build.py
+++ b/test_build.py
@@ -146,3 +146,6 @@ assert fake_bq_called, "Fake server did not recieve a request from the BQ client
 assert fake_bq_header_found, "X-KAGGLE-PROXY-DATA header was missing from the BQ request."
 print("bigquery proxy ok")
 
+import shap
+print("shap ok")
+


### PR DESCRIPTION
I checked that it installed with `pip install shap` and loaded correctly with `import shap` on the latest docker image. This package explains the output of any machine learning model, but with a fast implementation integrated with XGBoost, LightGBM, and scikit-learn tree models (see https://github.com/slundberg/shap). It was requested a while back to make an example Kaggle notebook available, so this PR is to make that possible.