### PR TITLE
update to continuumio/anaconda3:5.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM continuumio/anaconda3:5.0.1
+FROM continuumio/anaconda3:5.1.0
 
 ADD patches/ /tmp/patches/
 ADD patches/nbconvert-extensions.tpl /opt/kaggle/nbconvert-extensions.tpl


### PR DESCRIPTION
The last version of `continuumio/anaconda3` uses new version of `debian:latest` (9) and I hope Debian 9 has solved the problem https://github.com/ContinuumIO/docker-images/issues/83.