### PR TITLE
added apt-transport-https due to update of nvidia repos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04 AS nvidia
 
 FROM continuumio/anaconda3:5.0.1
 
+RUN apt-get update && apt-get install apt-transport-https
+
 COPY --from=nvidia /etc/apt/sources.list.d/cuda.list /etc/apt/sources.list.d/
 COPY --from=nvidia /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/
 COPY --from=nvidia /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/cuda.gpg


### PR DESCRIPTION
NVIDIA switched their repos from http to https, see the following commit in the nvidia/cuda docker file

https://gitlab.com/nvidia/cuda/commit/f31ece4bc9195a446f1dd6b9c8479c71fb295dfa

As a result we now need to install apt-transport-https in order to be able to use the NVIDIA repos. 

The present version of the Dockerfile has other issues too. There are several libraries that were recently updated and whose installation now fails. I am currently in the process of updating the respecive lines in the Dockerfile and will submit additional pull requests once I have tested and verified the changes. 
