### PR TITLE
'pip install fastdtw' added for near linear complexity temporal series alignment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -506,6 +506,7 @@ RUN pip install flashtext && \
     pip install conx && \
     pip install pandasql && \
     pip install trackml && \
+    pip install fastdtw && \
     ##### ^^^^ Add new contributions above here ^^^^ #####
     # clean up pip cache
     rm -rf /root/.cache/pip/*


### PR DESCRIPTION
Hello guys, first of all thanks for your amazing work! I love kaggle!

With that said, I was creating a kernel for audio-score alignment in your website and I noticed that there wasn't this fastdtw algorithm installed on your docker-python image. I have followed the instructions for pull request and I haven't found errors (at least not big ones!!). 

So I would be very grateful if you accept my pull request.

Regards,
Juan P. Braga Brum