### PR TITLE
add vw build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -506,6 +506,7 @@ RUN pip install flashtext && \
     pip install conx && \
     pip install pandasql && \
     pip install trackml && \
+    cd /usr/local/src && git clone https://github.com/JohnLangford/vowpal_wabbit.git && ./vowpal_wabbit/python/conda_install.sh && \
     ##### ^^^^ Add new contributions above here ^^^^ #####
     # clean up pip cache
     rm -rf /root/.cache/pip/*


### PR DESCRIPTION
Adding vowpal wabbit build from github. This follows #135. The sequence of `build` and `test` succeeds. 