### PR TITLE
Add pytorch-ignite with test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -490,7 +490,6 @@ RUN pip install flashtext && \
     pip install chainercv && \
     pip install plotly_express && \
     pip install albumentations && \
-    pip install allennlp && \
     pip install pytorch-ignite && \
     /tmp/clean-layer.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -481,6 +481,7 @@ RUN pip install flashtext && \
     pip install plotly_express && \
     pip install albumentations && \
     pip install allennlp && \
+    pip install pytorch-ignite && \
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages

--- a/tests/test_pytorch_ignite.py
+++ b/tests/test_pytorch_ignite.py
@@ -1,0 +1,13 @@
+import unittest
+
+from ignite.engine import Engine
+
+
+class TestPytorchIgnite(unittest.TestCase):
+    def test_engine(self):
+
+        def update_fn(engine, batch):
+            pass
+
+        engine = Engine(update_fn)
+        engine.run([0, 1, 2])


### PR DESCRIPTION
Adds `ignite` recently released library to help with training neural networks in PyTorch
More info [here](https://pytorch.org/ignite/)

- docker image built and tested as described in README
