### PR TITLE
Add downloads of pre-trained torchvision models.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -303,6 +303,7 @@ RUN export CXXFLAGS="-std=c++11" && \
     git clone -b v0.2.1 --recursive https://github.com/pytorch/vision && \
     cd vision && \
     python setup.py install && \
+    python /tmp/patches/torchvision_downloads.py && \
     # PyTorch Audio
     apt-get install -y sox libsox-dev libsox-fmt-all && \
     pip install cffi && \

--- a/patches/torchvision_downloads.py
+++ b/patches/torchvision_downloads.py
@@ -1,0 +1,11 @@
+from torch.utils import model_zoo
+from torchvision.models.resnet import model_urls
+
+
+def download_torchvision_models():
+    for url in model_urls.values():
+        model_zoo.load_url(url)
+
+
+if __name__ == '__main__':
+    download_torchvision_models()


### PR DESCRIPTION
Fixes #232. I think it would be convenient to have some pretrained torchvision models downloaded in the image to avoid extra code and hacky workarounds. I started with resnets because that's what I'm using right now (with fastai), but it would be straightforward to add other models that people are using frequently.