### PR TITLE
Use ephemeral workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 String cron_string = BRANCH_NAME == "master" ? "H 12 * * 1-5" : ""
 
 pipeline {
-  agent { label 'linux && !gpu' }
+  agent { label 'ephemeral-linux && !gpu' }
   options {
     disableConcurrentBuilds()
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 String cron_string = BRANCH_NAME == "master" ? "H 12 * * 1-5" : ""
 
 pipeline {
-  agent { label 'ephemeral-linux && !gpu' }
+  agent { label 'ephemeral-linux' }
   options {
     disableConcurrentBuilds()
   }


### PR DESCRIPTION
The new ephemeral workers are using an image with all the dependencies setup properly.

This solves the connectivity issue with the debian repo.