### PR TITLE
Add tensorflow probability for GPU

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -554,6 +554,7 @@ RUN pip install flashtext && \
     pip install pyupset && \
     pip install -e git+https://github.com/SohierDane/BigQuery_Helper#egg=bq_helper && \
     pip install git+https://github.com/Kaggle/learntools && \
+    pip install tfp-nightly-gpu && \
     ##### ^^^^ Add new contributions above here
     # clean up pip cache
     rm -rf /root/.cache/pip/*


### PR DESCRIPTION
This PR adds tensorflow probability (aka TFP) for GPU. 

TFP is a newish project from the TensorFlow team. I'm excited about it and hope to get other Kaggle users excited about it.  

It has tensorflow as a requirement.  So as long as we are building TensorFlow from source, the `pip install tfp-nightly-gpu` probably needs to occur after the TF install.

I have not tested this, because I'm not sure I understand the current status of the CUDA branch, and I @crawforc3 probably has a more efficient testing workflow.

I'll create a separate PR for master with `tfp-nightly` which is the non-GPU install.
