### PR TITLE
Patch .bashrc to set up pip to enable pip install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -535,6 +535,11 @@ ADD patches/sitecustomize.py /root/.local/lib/python3.6/site-packages/sitecustom
 # Set backend for matplotlib
 ENV MPLBACKEND "agg"
 
+# Set up pip to enable pip install.
+ADD patches/kaggle_bashrc /root/.bashrc
+# Patch the system-wide bashrc file for non-root users.
+RUN cat /root/.bashrc >> /etc/bash.bashrc
+
 # Finally, apply any locally defined patches.
 RUN /bin/bash -c \
     "cd / && for p in $(ls /tmp/patches/*.patch); do echo '= Applying patch '\${p}; patch -p2 < \${p}; done"

--- a/Dockerfile
+++ b/Dockerfile
@@ -536,9 +536,10 @@ ADD patches/sitecustomize.py /root/.local/lib/python3.6/site-packages/sitecustom
 ENV MPLBACKEND "agg"
 
 # Set up pip to enable pip install.
-ADD patches/kaggle_bashrc /root/.bashrc
+ADD patches/kaggle_bashrc /root
 # Patch the system-wide bashrc file for non-root users.
-RUN cat /root/.bashrc >> /etc/bash.bashrc
+RUN cat /root/kaggle_bashrc >> /etc/bash.bashrc
+RUN rm /root/kaggle_bashrc
 
 # Finally, apply any locally defined patches.
 RUN /bin/bash -c \

--- a/patches/kaggle_bashrc
+++ b/patches/kaggle_bashrc
@@ -1,0 +1,31 @@
+
+# Kaggle-specific .bashrc script to be appended to /etc/bash.bashrc to apply it
+# when any user session starts.
+# This script sets up pip to enable a user to install and use python modules via
+# pip intall. $KAGGLE_WORKING_DIR should be available for it to work.
+
+if [[ ! -z "${KAGGLE_WORKING_DIR}" ]]; then
+    PIP_INSTALL_PREFIX_DIR="${KAGGLE_WORKING_DIR}/pip"
+    PIP_CONFIG_FILE_PATH="${KAGGLE_WORKING_DIR}/config/pip/pip.conf"
+
+    # Create a directory for pip to install modules.
+    mkdir -p ${PIP_INSTALL_PREFIX_DIR}
+
+    # Create pip config file to use the prefix directory created above for
+    # installation. Also, ignore-installed is set to true to prevent pip
+    # from trying to remove existing modules from the read-only filesystem.
+    mkdir -p `dirname ${PIP_CONFIG_FILE_PATH}`
+    echo "[install]\nprefix=${PIP_INSTALL_PREFIX_DIR}\nignore-installed=true" > ${PIP_CONFIG_FILE_PATH}
+    # Instruct pip to use this config file.
+    export PIP_CONFIG_FILE=${PIP_CONFIG_FILE_PATH}
+
+    # Set up PYTHONPATH correctly to include the user-installed library.
+    # Note that the pip prefix directory overrides the system default to enable
+    # a user to use his/her installed one.
+    # TODO(dsjang): Currently "lib/python3.6/site-packages" is hard-coded
+    # throughout Dockerfile. Parameterize it to avoid a version mismatch. 
+    export PYTHONPATH=${PIP_INSTALL_PREFIX_DIR}/lib/python3.6/site-packages:${PYTHONPATH}
+
+    # Include pip-installed binaries in PATH.
+    export PATH=${PATH}:${PIP_INSTALL_PREFIX_DIR}/bin
+fi


### PR DESCRIPTION
Create a directory for pip to install modules via users' "pip install" command.

Set up PIP_CONFIG_FILE & PYTHONPATH to use those modeuls in a Kernel session.

Currently this change is no-op until we populate KAGGLE_WORKING_DIR from the worker.