### PR TITLE
Learn tools quick update

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Next run the build:
 Finally run the tests:
 
 ```
-./tests
+./test
 ```
 
 Then submit your pull request, and you're all set!

--- a/kaggle_tools_update.Dockerfile
+++ b/kaggle_tools_update.Dockerfile
@@ -1,11 +1,14 @@
-# This Dockerfile is a temporary solution to unblock the 
-# Kaggle team by updating their library latest using
-# the latest python image.
-# This is needed until we resolved the issues with the
-# main build.
+# This Dockerfile is a temporary solution until we
+# resolved the broken main build.
+
+# This Dockerfile creates a new image based on our
+# current published python image with the latest
+# version of the LearnTools library to allow us
+# to release new Learn content.
 
 # Usage:
-#   docker build --pull --rm -t kaggle/python-build -f kaggle_tools_update.Dockerfile .
+#   docker rmi gcr.io/kaggle-images/python:latest
+#   docker build --rm -t kaggle/python-build -f kaggle_tools_update.Dockerfile .
 #   ./test
 #   ./push (if tests are passing)
 

--- a/kaggle_tools_update.Dockerfile
+++ b/kaggle_tools_update.Dockerfile
@@ -1,0 +1,14 @@
+# This Dockerfile is a temporary solution to unblock the 
+# community team by updating their library latest using
+# the latest python image.
+# This is needed until we resolved the issues with the
+# main build.
+
+# Usage:
+#   docker build --rm -t kaggle/python-build -f kaggle_tools_update.Dockerfile .
+#   ./test
+#   ./push (if tests are passing)
+
+FROM gcr.io/kaggle-images/python:latest
+
+RUN pip install git+https://github.com/Kaggle/learntools

--- a/kaggle_tools_update.Dockerfile
+++ b/kaggle_tools_update.Dockerfile
@@ -1,14 +1,14 @@
 # This Dockerfile is a temporary solution to unblock the 
-# community team by updating their library latest using
+# Kaggle team by updating their library latest using
 # the latest python image.
 # This is needed until we resolved the issues with the
 # main build.
 
 # Usage:
-#   docker build --rm -t kaggle/python-build -f kaggle_tools_update.Dockerfile .
+#   docker build --pull --rm -t kaggle/python-build -f kaggle_tools_update.Dockerfile .
 #   ./test
 #   ./push (if tests are passing)
 
 FROM gcr.io/kaggle-images/python:latest
 
-RUN pip install git+https://github.com/Kaggle/learntools
+RUN pip install --upgrade git+https://github.com/Kaggle/learntools

--- a/test_build.py
+++ b/test_build.py
@@ -15,7 +15,11 @@ from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.optimizers import SGD
 print("Keras ok")
 
-# Test learntools
+# Test Kaggle learntools
+from learntools.core import binder; binder.bind(globals())
+from learntools.python.ex1 import *
+color="blue"
+q0.check()
 
 # PyTorch smoke test based on http://pytorch.org/tutorials/beginner/nlp/deep_learning_tutorial.html
 import torch

--- a/test_build.py
+++ b/test_build.py
@@ -15,6 +15,8 @@ from keras.layers.convolutional import Convolution2D, MaxPooling2D
 from keras.optimizers import SGD
 print("Keras ok")
 
+# Test learntools
+
 # PyTorch smoke test based on http://pytorch.org/tutorials/beginner/nlp/deep_learning_tutorial.html
 import torch
 import torch.nn as tnn

--- a/test_build.py
+++ b/test_build.py
@@ -20,6 +20,7 @@ from learntools.core import binder; binder.bind(globals())
 from learntools.python.ex1 import *
 color="blue"
 q0.check()
+print("learntools ok")
 
 # PyTorch smoke test based on http://pytorch.org/tutorials/beginner/nlp/deep_learning_tutorial.html
 import torch


### PR DESCRIPTION
The community team needs the latest version of Learn Tools in order to launch new learn content. 

In order to unblock them quickly, I created a new docker file that build a new image with the latest learntools package from the latest stable.

This is a temporary workaround and hopefully, we will be back soon to a state where we can simply build a new image with all the latest dependencies.

I also added a test to confirm that learntools works as expected. Output from the test run
```
Tensorflow ok
Using TensorFlow backend.
Keras ok
Correct: What?! You got it right without needing a hint or anything? Drats. Well hey, you should still continue to the next step to get some practice asking for a hint and checking solutions. (Even though you obviously don't need any help here.)
learntools ok
...
```