### PR TITLE
Improve build script by using the --pull flag

### DIFF
--- a/build
+++ b/build
@@ -6,6 +6,5 @@ set -e
 if [[ "$1" ==  "--use-cache" ]]; then
     docker build --rm -t kaggle/python-build .
 else
-    docker pull continuumio/anaconda3:latest
-    docker build --rm --no-cache -t kaggle/python-build .
+    docker build --pull --rm --no-cache -t kaggle/python-build .
 fi


### PR DESCRIPTION
We are not using the latest image from anaconda so :latest != to our pinned base image in the FROM command. This means we pull an image we don't end up using. With `--pull`, we ensure we pull the latest image that matches the version specified in the docker FROM command. 