### PR TITLE
Install pytorch for cpu on master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -235,7 +235,7 @@ RUN pip install scipy && \
     # PyTorch
     export CXXFLAGS="-std=c++11" && \
     export CFLAGS="-std=c99" && \
-    conda install -y pytorch torchvision -c pytorch && \
+    conda install -y pytorch-cpu torchvision-cpu -c pytorch && \
     # PyTorch Audio
     apt-get install -y sox libsox-dev libsox-fmt-all && \
     pip install cffi && \


### PR DESCRIPTION
pytorch installs the gpu version by default now unless we use the cpu package explicitly.

The build was failing with the following error:

```
Aug 23 23:25:17 [0m[91mTraceback (most recent call last):
Aug 23 23:25:17   File "setup.py", line 4, in <module>
Aug 23 23:25:17     from torch.utils.cpp_extension import BuildExtension, CppExtension
Aug 23 23:25:17   File "/opt/conda/lib/python3.6/site-packages/torch/__init__.py", line 80, in <module>
Aug 23 23:25:17     from torch._C import *
Aug 23 23:25:17 ImportError: libcudart.so.9.0: cannot open shared object file: No such file or directory
```