### PR TITLE
Move gensim after downgrading to python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list &
     apt-get -y install cmake
 
 RUN pip install seaborn python-dateutil dask pytagcloud pyyaml joblib \
-    husl geopy ml_metrics mne pyshp gensim && \
+    husl geopy ml_metrics mne pyshp && \
     conda install -y -c conda-forge spacy && python -m spacy download en && \
     python -m spacy download en_core_web_lg && \
     # The apt-get version of imagemagick is out of date and has compatibility issues, so we build from source
@@ -65,6 +65,7 @@ RUN conda install -y python=3.6.6 && \
 
 RUN apt-get install -y libfreetype6-dev && \
     apt-get install -y libglib2.0-0 libxext6 libsm6 libxrender1 libfontconfig1 --fix-missing && \
+    pip install gensim && \
     # textblob
     pip install textblob && \
     #word cloud


### PR DESCRIPTION
Otherwise, the package gets silently removed.