### PR TITLE
Build CPU & GPU images from the same branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM gcr.io/kaggle-images/python-tensorflow-whl:1.11.0-py36 as tensorflow_whl
 FROM continuumio/anaconda3:5.0.1
 
-# This is necessary to for apt to access HTTPS sources
+# This is necessary for apt to access HTTPS sources
 RUN apt-get update && \
     apt-get install apt-transport-https
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,9 @@
+FROM gcr.io/kaggle-images/python-tensorflow-whl:1.11.0-py36 as tensorflow_whl
 FROM continuumio/anaconda3:5.0.1
+
+# This is necessary to for apt to access HTTPS sources
+RUN apt-get update && \
+    apt-get install apt-transport-https
 
 ADD patches/ /tmp/patches/
 ADD patches/nbconvert-extensions.tpl /opt/kaggle/nbconvert-extensions.tpl
@@ -6,7 +11,7 @@ ADD patches/nbconvert-extensions.tpl /opt/kaggle/nbconvert-extensions.tpl
     # Use a fixed apt-get repo to stop intermittent failures due to flaky httpredir connections,
     # as described by Lionel Chan at http://stackoverflow.com/a/37426929/5881346
 RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list && \
-    apt-get update && apt-get install -y build-essential && \
+    apt-get update && apt-get install -y build-essential unzip && \
     # https://stackoverflow.com/a/46498173
     conda update -y conda && conda update -y python && \
     pip install --upgrade pip && \
@@ -32,33 +37,18 @@ RUN pip install seaborn python-dateutil dask pytagcloud pyyaml joblib \
     # clean up ImageMagick source files
     cd ../ && rm -rf ImageMagick*
 
-RUN apt-get update && apt-get install -y python-software-properties zip && \
-    echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu precise main" | tee -a /etc/apt/sources.list && \
-    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu precise main" | tee -a /etc/apt/sources.list && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys EEA14886 C857C906 2B90D010 && \
-    apt-get update && \
-    echo debconf shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
-    echo debconf shared/accepted-oracle-license-v1-1 seen true | debconf-set-selections && \
-    apt-get install -y oracle-java8-installer && \
-    echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list && \
-    curl https://bazel.build/bazel-release.pub.gpg | apt-key add - && \
-    apt-get update && apt-get install -y bazel && \
-    apt-get upgrade -y bazel
-
 # Tensorflow doesn't support python 3.7 yet. See https://github.com/tensorflow/tensorflow/issues/20517
 # Fix to install tf 1.10:: Downgrade python 3.7->3.6.6 and downgrade Pandas 0.23.3->0.23.2
 RUN conda install -y python=3.6.6 && \
     pip install pandas==0.23.2 && \
     # Another fix for TF 1.10 https://github.com/tensorflow/tensorflow/issues/21518
     pip install keras_applications==1.0.4 --no-deps && \
-    pip install keras_preprocessing==1.0.2 --no-deps && \
-    cd /usr/local/src && \
-    git clone https://github.com/tensorflow/tensorflow && \
-    cd tensorflow && \
-    cat /dev/null | ./configure && \
-    bazel build --config=opt //tensorflow/tools/pip_package:build_pip_package && \
-    bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_pkg && \
-    pip install /tmp/tensorflow_pkg/tensorflow*.whl
+    pip install keras_preprocessing==1.0.2 --no-deps
+
+# Install tensorflow from a pre-built wheel
+COPY --from=tensorflow_whl /tmp/tensorflow_cpu/*.whl /tmp/tensorflow_cpu/
+RUN pip install /tmp/tensorflow_cpu/tensorflow*.whl && \
+    rm -rf /tmp/tensorflow_cpu
 
 RUN apt-get install -y libfreetype6-dev && \
     apt-get install -y libglib2.0-0 libxext6 libsm6 libxrender1 libfontconfig1 --fix-missing && \

--- a/build
+++ b/build
@@ -1,29 +1,49 @@
 #!/bin/bash
-#
-# Build a new Python Docker image.
-#
-# Usage:
-#   ./build [--gpu] [--use-cache]
-#
-# Options:
-#   --gpu: Build an image with GPU support.
-#   --use-cache: Use layer cache when building a new image.
-# 
 set -e
-set -x
+
+usage() {
+cat << EOF
+Usage: $0 [OPTIONS]
+Build a new Python Docker image.
+
+Options:
+    -g, --gpu       Build an image with GPU support.
+    -c, --use-cache Use layer cache when building a new image.
+EOF
+}
 
 CACHE_FLAG="--no-cache"
-IMAGE_TAG="kaggle/python-build"
 DOCKERFILE="Dockerfile"
+IMAGE_TAG="kaggle/python-build"
 
-if [[ "$1" == "--gpu" ]]; then
-    IMAGE_TAG="kaggle/python-gpu-build"
-    DOCKERFILE="gpu.Dockerfile"
+while :; do
+    case "$1" in 
+        -h|--help)
+            usage
+            exit
+            ;;
+        -g|--gpu)
+            IMAGE_TAG="kaggle/python-gpu-build"
+            DOCKERFILE="gpu.Dockerfile"
+            ;;
+        -c|--use-cache)
+            CACHE_FLAG=""
+            ;;
+        -?*)
+            usage
+            printf 'ERROR: Unknown option: %s\n' "$1" >&2
+            exit
+            ;;
+        *)            
+            break
+    esac
+
     shift
-fi
+done
 
-if [[ "$1" ==  "--use-cache" ]]; then
-    CACHE_FLAG=""
-fi
+readonly CACHE_FLAG
+readonly DOCKERFILE
+readonly IMAGE_TAG
 
-docker build --rm $CACHE_FLAG -t $IMAGE_TAG -f $DOCKERFILE .
+set -x
+docker build --rm $CACHE_FLAG -t "$IMAGE_TAG" -f "$DOCKERFILE" .

--- a/build
+++ b/build
@@ -26,4 +26,4 @@ if [[ "$1" ==  "--use-cache" ]]; then
     CACHE_FLAG=""
 fi
 
-docker build --rm -t $CACHE_FLAG $IMAGE_TAG -f $DOCKERFILE .
+docker build --rm $CACHE_FLAG -t $IMAGE_TAG -f $DOCKERFILE .

--- a/build
+++ b/build
@@ -1,10 +1,29 @@
 #!/bin/bash
+#
+# Build a new Python Docker image.
+#
+# Usage:
+#   ./build [--gpu] [--use-cache]
+#
+# Options:
+#   --gpu: Build an image with GPU support.
+#   --use-cache: Use layer cache when building a new image.
+# 
 set -e
+set -x
 
-# Default behavior is to do everything from scratch.
-# The --use-cache option is useful if you're iterating on a broken build.
-if [[ "$1" ==  "--use-cache" ]]; then
-    docker build --rm -t kaggle/python-build .
-else
-    docker build --pull --rm --no-cache -t kaggle/python-build .
+CACHE_FLAG="--no-cache"
+IMAGE_TAG="kaggle/python-build"
+DOCKERFILE="Dockerfile"
+
+if [[ "$1" == "--gpu" ]]; then
+    IMAGE_TAG="kaggle/python-gpu-build"
+    DOCKERFILE="gpu.Dockerfile"
+    shift
 fi
+
+if [[ "$1" ==  "--use-cache" ]]; then
+    CACHE_FLAG=""
+fi
+
+docker build --rm -t $CACHE_FLAG $IMAGE_TAG -f $DOCKERFILE .

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -1,6 +1,6 @@
 FROM nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04 AS nvidia
 FROM gcr.io/kaggle-images/python-tensorflow-whl:1.11.0-py36 as tensorflow_whl
-FROM kaggle/python-build
+FROM gcr.io/kaggle-images/python:staging
 
 # Cuda support
 COPY --from=nvidia /etc/apt/sources.list.d/cuda.list /etc/apt/sources.list.d/

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -1,0 +1,48 @@
+FROM nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04 AS nvidia
+FROM gcr.io/kaggle-images/python-tensorflow-whl:1.11.0-py36 as tensorflow_whl
+FROM kaggle/python-build
+
+# Cuda support
+COPY --from=nvidia /etc/apt/sources.list.d/cuda.list /etc/apt/sources.list.d/
+COPY --from=nvidia /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/
+COPY --from=nvidia /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/cuda.gpg
+
+ENV CUDA_VERSION=9.1.85
+ENV CUDA_PKG_VERSION=9-1=$CUDA_VERSION-1
+LABEL com.nvidia.volumes.needed="nvidia_driver"
+LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
+ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+# The stub is useful to us both for built-time linking and run-time linking, on CPU-only systems.
+# When intended to be used with actual GPUs, make sure to (besides providing access to the host
+# CUDA user libraries, either manually or through the use of nvidia-docker) exclude them. One
+# convenient way to do so is to obscure its contents by a bind mount:
+#   docker run .... -v /non-existing-directory:/usr/local/cuda/lib64/stubs:ro ...
+ENV LD_LIBRARY_PATH="/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs"
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+ENV NVIDIA_REQUIRE_CUDA="cuda>=9.0"
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      cuda-cudart-$CUDA_PKG_VERSION \
+      cuda-libraries-$CUDA_PKG_VERSION \
+      cuda-libraries-dev-$CUDA_PKG_VERSION \
+      cuda-nvml-dev-$CUDA_PKG_VERSION \
+      cuda-minimal-build-$CUDA_PKG_VERSION \
+      cuda-command-line-tools-$CUDA_PKG_VERSION \
+      libcudnn7=7.0.5.15-1+cuda9.1 \
+      libcudnn7-dev=7.0.5.15-1+cuda9.1 \
+      libnccl2=2.2.12-1+cuda9.1 \
+      libnccl-dev=2.2.12-1+cuda9.1 && \
+    ln -s /usr/local/cuda-9.1 /usr/local/cuda && \
+    ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
+
+# Reinstall packages with a separate version for GPU support
+# Tensorflow
+COPY --from=tensorflow_whl /tmp/tensorflow_gpu/*.whl /tmp/tensorflow_gpu/
+RUN pip uninstall -y tensorflow && \
+    pip install /tmp/tensorflow_gpu/tensorflow*.whl && \
+    rm -rf /tmp/tensorflow_gpu && \
+    conda uninstall -y pytorch-cpu torchvision-cpu && \
+    conda install -y pytorch torchvision -c pytorch
+
+# Install GPU-only packages
+RUN pip install pycuda

--- a/push
+++ b/push
@@ -1,35 +1,53 @@
 #!/bin/bash
-#
-# Push a newly-built image with the given label to gcr.io and DockerHub.
-#
-# Usage:
-#   ./push [--gpu] [LABEL]
-#
-# Description:
-#   LABEL: Docker image label. Defaults to "testing".
-#
-# Options:
-#   --gpu: Psuh the image with GPU support.
-# 
 set -e
-set -x
+
+usage() {
+cat << EOF
+Usage: $0 [OPTIONS] [LABEL]
+Push a newly-built image with the given LABEL to gcr.io and DockerHub.
+
+Options:
+    -g, --gpu   Push the image with GPU support.
+EOF
+}
 
 SOURCE_IMAGE="kaggle/python-build"
 TARGET_IMAGE="gcr.io/kaggle-images/python"
 
-if [[ "$1" == "--gpu" ]]; then
-    SOURCE_IMAGE="kaggle/python-gpu-build"
-    TARGET_IMAGE="gcr.io/kaggle-private-byod/python"
+while :; do
+    case "$1" in 
+        -h|--help)
+            usage
+            exit
+            ;;
+        -g|--gpu)
+            SOURCE_IMAGE="kaggle/python-gpu-build"
+            TARGET_IMAGE="gcr.io/kaggle-private-byod/python"
+            ;;
+        -?*)
+            usage
+            printf 'ERROR: Unknown option: %s\n' "$1" >&2
+            exit
+            ;;
+        *)            
+            break
+    esac
+
     shift
-fi
+done
 
 LABEL=${1:-testing}
 
-docker tag $SOURCE_IMAGE:latest $TARGET_IMAGE:$LABEL
-gcloud docker -- push $TARGET_IMAGE:$LABEL
+readonly SOURCE_IMAGE
+readonly TARGET_IMAGE
+readonly LABEL
+
+set -x
+docker tag "${SOURCE_IMAGE}:latest" "${TARGET_IMAGE}:${LABEL}"
+gcloud docker -- push "${TARGET_IMAGE}:${LABEL}"
 
 # Only CPU images are made public at this time.
 if [[ "$LABEL" == "latest" && SOURCE_IMAGE = "kaggle/python-build" ]]; then
-  docker tag $SOURCE_IMAGE:latest kaggle/python:$LABEL
-  docker push kaggle/python:$LABEL
+  docker tag "${SOURCE_IMAGE}:latest" "kaggle/python:${LABEL}"
+  docker push "kaggle/python:${LABEL}"
 fi

--- a/push
+++ b/push
@@ -1,13 +1,32 @@
 #!/bin/bash
+#
+# Push a newly-built image with the given label to gcr.io and DockerHub.
+#
+# Usage:
+#   ./push [--gpu] [label]
+#
+# Description:
+#   label: Docker image label. Defaults to "testing".
+#
+# Options:
+#   --gpu: Psuh the image with GPU support.
+# 
 set -e
-set +x
+set -x
+
+IMAGE_TAG="kaggle/python-build:latest"
+
+if [[ "$1" == "--gpu" ]]; then
+    IMAGE_TAG="kaggle/python-gpu-build:latest"
+    shift
+fi
 
 label=${1:-testing}
 
-docker tag kaggle/python-build:latest gcr.io/kaggle-images/python:${label}
+docker tag $IMAGE_TAG gcr.io/kaggle-images/python:${label}
 gcloud docker -- push gcr.io/kaggle-images/python:${label}
 
 if [[ "$label" == "latest" ]]; then
-  docker tag kaggle/python-build:latest kaggle/python:${label}
+  docker tag $IMAGE_TAG kaggle/python:${label}
   docker push kaggle/python:${label}
 fi

--- a/push
+++ b/push
@@ -3,10 +3,10 @@
 # Push a newly-built image with the given label to gcr.io and DockerHub.
 #
 # Usage:
-#   ./push [--gpu] [label]
+#   ./push [--gpu] [LABEL]
 #
 # Description:
-#   label: Docker image label. Defaults to "testing".
+#   LABEL: Docker image label. Defaults to "testing".
 #
 # Options:
 #   --gpu: Psuh the image with GPU support.
@@ -14,19 +14,22 @@
 set -e
 set -x
 
-IMAGE_TAG="kaggle/python-build:latest"
+SOURCE_IMAGE="kaggle/python-build"
+TARGET_IMAGE="gcr.io/kaggle-images/python"
 
 if [[ "$1" == "--gpu" ]]; then
-    IMAGE_TAG="kaggle/python-gpu-build:latest"
+    SOURCE_IMAGE="kaggle/python-gpu-build"
+    TARGET_IMAGE="gcr.io/kaggle-private-byod/python"
     shift
 fi
 
-label=${1:-testing}
+LABEL=${1:-testing}
 
-docker tag $IMAGE_TAG gcr.io/kaggle-images/python:${label}
-gcloud docker -- push gcr.io/kaggle-images/python:${label}
+docker tag $SOURCE_IMAGE:latest $TARGET_IMAGE:$LABEL
+gcloud docker -- push $TARGET_IMAGE:$LABEL
 
-if [[ "$label" == "latest" ]]; then
-  docker tag $IMAGE_TAG kaggle/python:${label}
-  docker push kaggle/python:${label}
+# Only CPU images are made public at this time.
+if [[ "$LABEL" == "latest" && SOURCE_IMAGE = "kaggle/python-build" ]]; then
+  docker tag $SOURCE_IMAGE:latest kaggle/python:$LABEL
+  docker push kaggle/python:$LABEL
 fi

--- a/test
+++ b/test
@@ -1,14 +1,4 @@
 #!/bin/bash
-#
-# 
-# 
-#
-# Usage:
-#   ./test [--gpu]
-#
-# Options:
-#   --gpu: Run tests for the GPU image
-# 
 set -e
 
 usage() {

--- a/test
+++ b/test
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# Run tests for a newly-built Python Docker image.
-# By default, it runs the tests for the CPU image.
+# 
+# 
 #
 # Usage:
 #   ./test [--gpu]
@@ -9,19 +9,48 @@
 # Options:
 #   --gpu: Run tests for the GPU image
 # 
-
 set -e
-set -x
+
+usage() {
+cat << EOF
+Usage: $0 [OPTIONS]
+Run tests for a newly-built Python Docker image.
+By default, it runs the tests for the CPU image.
+
+Options:
+    -g, --gpu   Run tests for the GPU image.
+EOF
+}
 
 IMAGE_TAG="kaggle/python-build"
 ADDITONAL_OPTS=""
 
-if [[ "$1" == "--gpu" ]]; then
-    IMAGE_TAG="kaggle/python-gpu-build"
-    ADDITONAL_OPTS="-v /tmp/empty_dir:/usr/local/cuda/lib64/stubs:ro"
-    shift
-fi
+while :; do
+    case "$1" in 
+        -h|--help)
+            usage
+            exit
+            ;;
+        -g|--gpu)
+            IMAGE_TAG="kaggle/python-gpu-build"
+            ADDITONAL_OPTS="-v /tmp/empty_dir:/usr/local/cuda/lib64/stubs:ro"
+            ;;
+        -?*)
+            usage
+            printf 'ERROR: Unknown option: %s\n' "$1" >&2
+            exit
+            ;;
+        *)            
+            break
+    esac
 
+    shift
+done
+
+readonly IMAGE_TAG
+readonly ADDITONAL_OPTS
+
+set -x
 rm -rf /tmp/python-build
 docker rm jupyter_test || true
 mkdir -p /tmp/python-build/tmp
@@ -39,5 +68,5 @@ docker run --rm -t --read-only --net=none \
     -v /tmp/python-build/tmp:/tmp -v /tmp/python-build/devshm:/dev/shm \
     -w=/working \
     $ADDITONAL_OPTS \
-    $IMAGE_TAG \
+    "$IMAGE_TAG" \
     /bin/bash -c 'python -m unittest discover -s /input/tests'

--- a/test
+++ b/test
@@ -1,6 +1,24 @@
 #!/bin/bash
+#
+# Run tests for a newly-built Python Docker image.
+# By default, it runs the tests for the CPU image.
+#
+# Usage:
+#   ./test [--gpu]
+#
+# Options:
+#   --gpu: Run tests for the GPU image
+# 
+
 set -e
-set +x
+set -x
+
+IMAGE_TAG="kaggle/python-build"
+
+if [[ "$1" == "--gpu" ]]; then
+    IMAGE_TAG="kaggle/python-gpu-build"
+    shift
+fi
 
 rm -rf /tmp/python-build
 docker rm jupyter_test || true
@@ -8,7 +26,7 @@ mkdir -p /tmp/python-build/tmp
 mkdir -p /tmp/python-build/devshm
 mkdir -p /tmp/python-build/working
 # Check that Jupyter server can run; if it dies on startup, the `docker kill` command will throw an error
-docker run -d --name=jupyter_test --read-only --net=none -e HOME=/tmp -v $PWD:/input:ro -v /tmp/python-build/working:/working -w=/working -v /tmp/python-build/tmp:/tmp -v /tmp/python-build/devshm:/dev/shm kaggle/python-build jupyter notebook --allow-root --ip="*"
+docker run -d --name=jupyter_test --read-only --net=none -e HOME=/tmp -v $PWD:/input:ro -v /tmp/python-build/working:/working -w=/working -v /tmp/python-build/tmp:/tmp -v /tmp/python-build/devshm:/dev/shm $IMAGE_TAG jupyter notebook --allow-root --ip="*"
 sleep 3
 docker kill jupyter_test && docker rm jupyter_test
 docker run --rm -t --read-only --net=none \
@@ -18,5 +36,5 @@ docker run --rm -t --read-only --net=none \
     -v $PWD:/input:ro -v /tmp/python-build/working:/working \
     -v /tmp/python-build/tmp:/tmp -v /tmp/python-build/devshm:/dev/shm \
     -w=/working \
-    kaggle/python-build \
+    $IMAGE_TAG \
     /bin/bash -c 'python -m unittest discover -s /input/tests'

--- a/test
+++ b/test
@@ -47,7 +47,7 @@ mkdir -p /tmp/python-build/tmp
 mkdir -p /tmp/python-build/devshm
 mkdir -p /tmp/python-build/working
 # Check that Jupyter server can run; if it dies on startup, the `docker kill` command will throw an error
-docker run -d --name=jupyter_test --read-only --net=none -e HOME=/tmp -v $PWD:/input:ro -v /tmp/python-build/working:/working -w=/working -v /tmp/python-build/tmp:/tmp -v /tmp/python-build/devshm:/dev/shm $IMAGE_TAG jupyter notebook --allow-root --ip="*"
+docker run -d --name=jupyter_test --read-only --net=none -e HOME=/tmp -v $PWD:/input:ro -v /tmp/python-build/working:/working -w=/working -v /tmp/python-build/tmp:/tmp -v /tmp/python-build/devshm:/dev/shm "$IMAGE_TAG" jupyter notebook --allow-root --ip="*"
 sleep 3
 docker kill jupyter_test && docker rm jupyter_test
 docker run --rm -t --read-only --net=none \

--- a/test
+++ b/test
@@ -14,9 +14,11 @@ set -e
 set -x
 
 IMAGE_TAG="kaggle/python-build"
+ADDITONAL_OPTS=""
 
 if [[ "$1" == "--gpu" ]]; then
     IMAGE_TAG="kaggle/python-gpu-build"
+    ADDITONAL_OPTS="-v /tmp/empty_dir:/usr/local/cuda/lib64/stubs:ro"
     shift
 fi
 
@@ -36,5 +38,6 @@ docker run --rm -t --read-only --net=none \
     -v $PWD:/input:ro -v /tmp/python-build/working:/working \
     -v /tmp/python-build/tmp:/tmp -v /tmp/python-build/devshm:/dev/shm \
     -w=/working \
+    $ADDITONAL_OPTS \
     $IMAGE_TAG \
     /bin/bash -c 'python -m unittest discover -s /input/tests'

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,6 @@
+"""Common testing setup"""
+
+import os
+import unittest
+
+gpu_test = unittest.skipIf(len(os.environ.get('CUDA_VERSION', '')) == 0, 'Not running GPU tests')

--- a/tests/test_nvidia.py
+++ b/tests/test_nvidia.py
@@ -5,9 +5,6 @@ import subprocess
 import sys
 import unittest
 
-import common
-import pycuda.driver
-
 from common import gpu_test
 
 
@@ -19,7 +16,8 @@ class TestNvidia(unittest.TestCase):
         self.assertEqual(0, smi.returncode)
 
     @gpu_test
-    def test_pycuda(self):       
+    def test_pycuda(self):   
+        import pycuda.driver    
         pycuda.driver.init()
         gpu_name = pycuda.driver.Device(0).name() 
         self.assertNotEqual(0, len(gpu_name))

--- a/tests/test_nvidia.py
+++ b/tests/test_nvidia.py
@@ -1,0 +1,26 @@
+"""Tests for general GPU support"""
+
+import os
+import subprocess
+import sys
+import unittest
+
+import common
+import pycuda.driver
+
+from common import gpu_test
+
+
+class TestNvidia(unittest.TestCase):
+    @gpu_test
+    def test_system_management_interface(self):
+        smi = subprocess.Popen(['nvidia-smi'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        smi.communicate()
+        self.assertEqual(0, smi.returncode)
+
+    @gpu_test
+    def test_pycuda(self):       
+        pycuda.driver.init()
+        gpu_name = pycuda.driver.Device(0).name() 
+        self.assertNotEqual(0, len(gpu_name))
+

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -16,10 +16,20 @@ class TestPyTorch(unittest.TestCase):
         linear_torch(data_torch)
 
     @gpu_test
-    def test_gpu(self):
+    def test_gpu_computation(self):
         cuda = torch.device('cuda')  
         a = torch.tensor([1., 2.], device=cuda)
 
         result = a.sum()
 
         self.assertEqual(torch.tensor([3.], device=cuda), result)
+
+    @gpu_test
+    def test_cuda_nn(self):
+        # These throw if cuda is misconfigured
+        tnn.GRUCell(10,10).cuda()
+        tnn.RNNCell(10,10).cuda()
+        tnn.LSTMCell(10,10).cuda()
+        tnn.GRU(10,10).cuda()
+        tnn.LSTM(10,10).cuda()
+        tnn.RNN(10,10).cuda()

--- a/tests/test_pytorch.py
+++ b/tests/test_pytorch.py
@@ -4,6 +4,9 @@ import torch
 import torch.nn as tnn
 import torch.autograd as autograd
 
+from common import gpu_test
+
+
 class TestPyTorch(unittest.TestCase):
     # PyTorch smoke test based on http://pytorch.org/tutorials/beginner/nlp/deep_learning_tutorial.html
     def test_nn(self):
@@ -11,3 +14,12 @@ class TestPyTorch(unittest.TestCase):
         linear_torch = tnn.Linear(5,3)
         data_torch = autograd.Variable(torch.randn(2, 5))
         linear_torch(data_torch)
+
+    @gpu_test
+    def test_gpu(self):
+        cuda = torch.device('cuda')  
+        a = torch.tensor([1., 2.], device=cuda)
+
+        result = a.sum()
+
+        self.assertEqual(torch.tensor([3.], device=cuda), result)

--- a/tests/test_tensorflow.py
+++ b/tests/test_tensorflow.py
@@ -1,6 +1,10 @@
 import unittest
 
+import numpy as np
 import tensorflow as tf
+
+from common import gpu_test
+
 
 class TestTensorflow(unittest.TestCase):
     def test_addition(self):        
@@ -10,3 +14,15 @@ class TestTensorflow(unittest.TestCase):
         result = sess.run(op)
 
         self.assertEqual(5, result)
+    
+    @gpu_test
+    def test_gpu(self):
+        with tf.device('/gpu:0'):
+            m1 = tf.constant([2.0, 3.0], shape=[1, 2], name='a')
+            m2 = tf.constant([3.0, 4.0], shape=[2, 1], name='b')
+            op = tf.matmul(m1, m2)
+
+            sess = tf.Session()
+            result = sess.run(op)
+
+            self.assertEqual(np.array(18, dtype=np.float32, ndmin=2), result)


### PR DESCRIPTION
This still keeps two images and won't require any changes to the worker codebase. Moving to a single image will be done later (design doc will be sent out soon).

Since this new GPU image is based off the CPU image, it reuses most of the layers which reduces the disk space used for the python images.

* Installed tensorflow from pre-built wheels (see #302).  Shaves 1h30 minutes from the build time (45 minutes to build the cpu version and 45 minutes the gpu version). This is the same approach colab took and once they migrate to cuda 9, we will be able to share these wheels. This allow for faster iteration time and easier image fixing/debugging in the future.
* Added a `gpu.Dockerfile` to build an image with cuda/nvidia support and pytorch & tensorflow with GPU support
* Updated the `build`, `test` and `push` scripts to support GPU through the `--gpu` flag.
* Updated the Jenkins configuration to build/test/push images
* Documented our `build`, `test` and `push` scripts
* Added GPU-only tests

All tests are passing for both the GPU and CPU image.

A run on the CI server is currently in-progress: https://ci.kaggle.net/job/docker-python/job/merge-2images/2