### PR TITLE
Add test for the lightgbm package

### DIFF
--- a/tests/test_lightgbm.py
+++ b/tests/test_lightgbm.py
@@ -28,6 +28,10 @@ class TestLightgbm(unittest.TestCase):
         }
 
         # Run only one round for faster test
-        gbm = lgb.train(params, lgb_train, num_boost_round=1, valid_sets=lgb_eval, early_stopping_rounds=1)
+        gbm = lgb.train(params,
+                        lgb_train,
+                        num_boost_round=1,
+                        valid_sets=lgb_eval,
+                        early_stopping_rounds=1)
 
         self.assertEqual(1, gbm.best_iteration)

--- a/tests/test_lightgbm.py
+++ b/tests/test_lightgbm.py
@@ -1,0 +1,33 @@
+import unittest
+
+import lightgbm as lgb
+
+from sklearn.datasets import load_iris
+
+class TestLightgbm(unittest.TestCase):
+    # Based on the "simple_example" from their documentation:
+    # https://github.com/Microsoft/LightGBM/blob/master/examples/python-guide/simple_example.py
+    def test_simple(self):
+        # Load a dataset aleady on disk
+        iris = load_iris()
+
+        lgb_train = lgb.Dataset(iris.data[:100], iris.target[:100])
+        lgb_eval = lgb.Dataset(iris.data[100:], iris.target[100:], reference=lgb_train)
+
+        params = {
+            'task': 'train',
+            'boosting_type': 'gbdt',
+            'objective': 'regression',
+            'metric': {'l2', 'auc'},
+            'num_leaves': 31,
+            'learning_rate': 0.05,
+            'feature_fraction': 0.9,
+            'bagging_fraction': 0.8,
+            'bagging_freq': 5,
+            'verbose': 0
+        }
+
+        # Run only one round for faster test
+        gbm = lgb.train(params, lgb_train, num_boost_round=1, valid_sets=lgb_eval, early_stopping_rounds=1)
+
+        self.assertEqual(1, gbm.best_iteration)


### PR DESCRIPTION
The latest version of the lightgbm package was depending on an old version of libc.

The following error message is shown to users who try to import it:
```
OSError: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.23' not found (required by /opt/conda/lib/python3.6/site-packages/lightgbm/lib_lightgbm.so)
```

I pinned the package to the previous version here: 
https://github.com/Kaggle/docker-python/commit/8ff8232d975e2b0a4b8cc11c4083624d2cb9b774