### PR TITLE
Always pull the latest parent images at build

### DIFF
--- a/build
+++ b/build
@@ -46,4 +46,4 @@ readonly DOCKERFILE
 readonly IMAGE_TAG
 
 set -x
-docker build --rm $CACHE_FLAG -t "$IMAGE_TAG" -f "$DOCKERFILE" .
+docker build --rm --pull $CACHE_FLAG -t "$IMAGE_TAG" -f "$DOCKERFILE" .


### PR DESCRIPTION
> --pull | Always attempt to pull a newer version of the image
https://docs.docker.com/engine/reference/commandline/build/#options




