### PR TITLE
Install cuDNN 7.2

### DIFF
--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04 AS nvidia
+FROM nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04 AS nvidia
 FROM gcr.io/kaggle-images/python-tensorflow-whl:1.11.0-py36 as tensorflow_whl
 FROM gcr.io/kaggle-images/python:staging
 
@@ -7,8 +7,8 @@ COPY --from=nvidia /etc/apt/sources.list.d/cuda.list /etc/apt/sources.list.d/
 COPY --from=nvidia /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/
 COPY --from=nvidia /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/cuda.gpg
 
-ENV CUDA_VERSION=9.2.88
-ENV CUDA_PKG_VERSION=9-2=$CUDA_VERSION-1
+ENV CUDA_VERSION=9.1.85
+ENV CUDA_PKG_VERSION=9-1=$CUDA_VERSION-1
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
@@ -22,19 +22,18 @@ ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 ENV NVIDIA_REQUIRE_CUDA="cuda>=9.0"
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        cuda-cupti-$CUDA_PKG_VERSION \
-        cuda-cudart-$CUDA_PKG_VERSION \
-        cuda-cudart-dev-$CUDA_PKG_VERSION \
-        cuda-libraries-$CUDA_PKG_VERSION \
-        cuda-libraries-dev-$CUDA_PKG_VERSION \
-        cuda-nvml-dev-$CUDA_PKG_VERSION \
-        cuda-minimal-build-$CUDA_PKG_VERSION \
-        cuda-command-line-tools-$CUDA_PKG_VERSION \
-        libcudnn7=7.2.1.38-1+cuda9.2 \
-        libcudnn7-dev=7.2.1.38-1+cuda9.2 \
-        libnccl2=2.2.13-1+cuda9.2 \
-        libnccl-dev=2.2.13-1+cuda9.2 && \
-    ln -s /usr/local/cuda-9.2 /usr/local/cuda && \
+      cuda-cupti-$CUDA_PKG_VERSION \
+      cuda-cudart-$CUDA_PKG_VERSION \
+      cuda-libraries-$CUDA_PKG_VERSION \
+      cuda-libraries-dev-$CUDA_PKG_VERSION \
+      cuda-nvml-dev-$CUDA_PKG_VERSION \
+      cuda-minimal-build-$CUDA_PKG_VERSION \
+      cuda-command-line-tools-$CUDA_PKG_VERSION \
+      libcudnn7=7.2.1.38-1+cuda9.0 \
+      libcudnn7-dev=7.2.1.38-1+cuda9.0 \
+      libnccl2=2.2.12-1+cuda9.1 \
+      libnccl-dev=2.2.12-1+cuda9.1 && \
+    ln -s /usr/local/cuda-9.1 /usr/local/cuda && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 
 # Reinstall packages with a separate version for GPU support

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04 AS nvidia
+FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04 AS nvidia
 FROM gcr.io/kaggle-images/python-tensorflow-whl:1.11.0-py36 as tensorflow_whl
 FROM gcr.io/kaggle-images/python:staging
 
@@ -7,8 +7,8 @@ COPY --from=nvidia /etc/apt/sources.list.d/cuda.list /etc/apt/sources.list.d/
 COPY --from=nvidia /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/
 COPY --from=nvidia /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/cuda.gpg
 
-ENV CUDA_VERSION=9.1.85
-ENV CUDA_PKG_VERSION=9-1=$CUDA_VERSION-1
+ENV CUDA_VERSION=9.2.88
+ENV CUDA_PKG_VERSION=9-2=$CUDA_VERSION-1
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
@@ -22,17 +22,19 @@ ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
 ENV NVIDIA_REQUIRE_CUDA="cuda>=9.0"
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      cuda-cudart-$CUDA_PKG_VERSION \
-      cuda-libraries-$CUDA_PKG_VERSION \
-      cuda-libraries-dev-$CUDA_PKG_VERSION \
-      cuda-nvml-dev-$CUDA_PKG_VERSION \
-      cuda-minimal-build-$CUDA_PKG_VERSION \
-      cuda-command-line-tools-$CUDA_PKG_VERSION \
-      libcudnn7=7.0.5.15-1+cuda9.1 \
-      libcudnn7-dev=7.0.5.15-1+cuda9.1 \
-      libnccl2=2.2.12-1+cuda9.1 \
-      libnccl-dev=2.2.12-1+cuda9.1 && \
-    ln -s /usr/local/cuda-9.1 /usr/local/cuda && \
+        cuda-cupti-$CUDA_PKG_VERSION \
+        cuda-cudart-$CUDA_PKG_VERSION \
+        cuda-cudart-dev-$CUDA_PKG_VERSION \
+        cuda-libraries-$CUDA_PKG_VERSION \
+        cuda-libraries-dev-$CUDA_PKG_VERSION \
+        cuda-nvml-dev-$CUDA_PKG_VERSION \
+        cuda-minimal-build-$CUDA_PKG_VERSION \
+        cuda-command-line-tools-$CUDA_PKG_VERSION \
+        libcudnn7=7.2.1.38-1+cuda9.2 \
+        libcudnn7-dev=7.2.1.38-1+cuda9.2 \
+        libnccl2=2.2.13-1+cuda9.2 \
+        libnccl-dev=2.2.13-1+cuda9.2 && \
+    ln -s /usr/local/cuda-9.2 /usr/local/cuda && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 
 # Reinstall packages with a separate version for GPU support

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -1,5 +1,6 @@
 import unittest
 
+import keras
 import numpy as np
 import pandas as pd
 

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -25,7 +25,8 @@ class TestKeras(unittest.TestCase):
             metrics=['accuracy'])
 
         model.fit(x_train, y_train, epochs=1, batch_size=32)
-    
+
+    # Uses convnet which depends on libcudnn when running on GPU
     def test_conv2d(self):
         # Generate dummy data
         x_train = np.random.random((100, 100, 100, 3))
@@ -52,7 +53,8 @@ class TestKeras(unittest.TestCase):
         model.add(Dense(10, activation='softmax'))
 
         sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
-        model.compile(loss='categorical_crossentropy', optimizer=sgd)
 
+        # This throws if libcudnn is not properly installed with on a GPU
+        model.compile(loss='categorical_crossentropy', optimizer=sgd)
         model.fit(x_train, y_train, batch_size=32, epochs=1)
-        score = model.evaluate(x_test, y_test, batch_size=32)
+        model.evaluate(x_test, y_test, batch_size=32)

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -1,10 +1,11 @@
 import unittest
 
+import numpy as np
 import pandas as pd
 
 from keras.models import Sequential
-from keras.layers import Dense
-from keras.optimizers import RMSprop
+from keras.layers import Dense, Dropout, Flatten, Conv2D, MaxPooling2D
+from keras.optimizers import RMSprop, SGD
 from keras.utils.np_utils import to_categorical
 
 class TestKeras(unittest.TestCase):
@@ -23,3 +24,34 @@ class TestKeras(unittest.TestCase):
             metrics=['accuracy'])
 
         model.fit(x_train, y_train, epochs=1, batch_size=32)
+    
+    def test_conv2d(self):
+        # Generate dummy data
+        x_train = np.random.random((100, 100, 100, 3))
+        y_train = keras.utils.to_categorical(np.random.randint(10, size=(100, 1)), num_classes=10)
+        x_test = np.random.random((20, 100, 100, 3))
+        y_test = keras.utils.to_categorical(np.random.randint(10, size=(20, 1)), num_classes=10)
+
+        model = Sequential()
+        # input: 100x100 images with 3 channels -> (100, 100, 3) tensors.
+        # this applies 32 convolution filters of size 3x3 each.
+        model.add(Conv2D(32, (3, 3), activation='relu', input_shape=(100, 100, 3)))
+        model.add(Conv2D(32, (3, 3), activation='relu'))
+        model.add(MaxPooling2D(pool_size=(2, 2)))
+        model.add(Dropout(0.25))
+
+        model.add(Conv2D(64, (3, 3), activation='relu'))
+        model.add(Conv2D(64, (3, 3), activation='relu'))
+        model.add(MaxPooling2D(pool_size=(2, 2)))
+        model.add(Dropout(0.25))
+
+        model.add(Flatten())
+        model.add(Dense(256, activation='relu'))
+        model.add(Dropout(0.5))
+        model.add(Dense(10, activation='softmax'))
+
+        sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+        model.compile(loss='categorical_crossentropy', optimizer=sgd)
+
+        model.fit(x_train, y_train, batch_size=32, epochs=1)
+        score = model.evaluate(x_test, y_test, batch_size=32)


### PR DESCRIPTION
Tensorflow requires cuDNN >= 7.2:
https://www.tensorflow.org/install/gpu#software_requirements

This caused a runtime issue for our users trying to do DeepLearning using tensorflow and GPUs:
https://www.kaggle.com/product-feedback/66339#390769

I pushed an image with this fix yesterday and this change just reflects that change. 

I added an extra test that uses DeepLearning to exercise cuDNN.