### PR TITLE
Install hep_ml, xgboost and lasagne using pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,24 +53,15 @@ RUN pip install /tmp/tensorflow_cpu/tensorflow*.whl && \
 RUN apt-get install -y libfreetype6-dev && \
     apt-get install -y libglib2.0-0 libxext6 libsm6 libxrender1 libfontconfig1 --fix-missing && \
     pip install gensim && \
-    # textblob
     pip install textblob && \
-    #word cloud
     pip install wordcloud && \
-    #igraph
     conda install -y -c conda-forge python-igraph && \
-    #xgboost
-    cd /usr/local/src && mkdir xgboost && cd xgboost && \
-    git clone --depth 1 --recursive https://github.com/dmlc/xgboost.git && cd xgboost && \
-    make && cd python-package && python setup.py install && \
+    pip install xgboost && \
     # Pinning to an older version. The latest release (2.2.0) depends on an old GLIBC version.
     # This cause the package to fail at import time with "version `GLIBC_2.23' not found"
     # TODO: Unpin once the latest release is fixed.
     pip install lightgbm==2.1.2 && \
-    #lasagne
-    cd /usr/local/src && mkdir Lasagne && cd Lasagne && \
-    git clone --depth 1 https://github.com/Lasagne/Lasagne.git && cd Lasagne && \
-    pip install -r requirements.txt && python setup.py install && \
+    pip install git+git://github.com/Lasagne/Lasagne.git && \
     #keras
     cd /usr/local/src && mkdir keras && cd keras && \
     git clone --depth 1 https://github.com/fchollet/keras.git && \
@@ -100,8 +91,7 @@ RUN apt-get install -y libfreetype6-dev && \
     apt-get install -y libatlas-base-dev && \
     cd /usr/local/src && git clone --depth 1 https://github.com/ztane/python-Levenshtein && \
     cd python-Levenshtein && python setup.py install && \
-    cd /usr/local/src && git clone --depth 1 https://github.com/arogozhnikov/hep_ml.git && \
-    cd hep_ml && pip install .  && \
+    pip install hep_ml && \
     # chainer
     pip install chainer && \
     # NLTK Project datasets
@@ -132,7 +122,6 @@ RUN apt-get install -y libfreetype6-dev && \
 # Make sure the dynamic linker finds the right libstdc++
 ENV LD_LIBRARY_PATH=/opt/conda/lib
 
-# Install Basemap via conda temporarily
 RUN apt-get -y install zlib1g-dev liblcms2-dev libwebp-dev libgeos-dev && \
     pip install matplotlib && \
     pip install pyshp && \

--- a/tests/test_hep_ml.py
+++ b/tests/test_hep_ml.py
@@ -1,0 +1,13 @@
+import unittest
+
+import numpy as np
+
+from hep_ml.preprocessing import BinTransformer
+
+class TestHepML(unittest.TestCase):
+    def test_preprocessing(self):
+        X = np.array([[1.1, 1.2, 1.3],[5.1, 6.4, 10.5]])
+        transformer = BinTransformer().fit(X)
+        new_X = transformer.transform(X)
+
+        self.assertEqual((2, 3), new_X.shape)

--- a/tests/test_lasagne.py
+++ b/tests/test_lasagne.py
@@ -1,0 +1,15 @@
+import unittest
+
+import lasagne
+import theano.tensor as T
+
+class TestLasagne(unittest.TestCase):
+    def test_network_definition(self):
+        input_var = T.tensor4('X')
+
+        network = lasagne.layers.InputLayer((None, 3, 32, 32), input_var)
+        network = lasagne.layers.Conv2DLayer(network, 64, (3, 3))
+
+        params = lasagne.layers.get_all_params(network, trainable=True)
+
+        self.assertEqual(2, len(params))


### PR DESCRIPTION
Part 1 of many PRs to try to standardize the way we install our packages.

I expanded the tests to prevent regression.

`lasagne` is not in pipy so I installed it using pip git install.
`xgboost` and `hep_ml` had the same version in pipy than the one we were using.