### PR TITLE
Removing unmaintained and unused opendeep package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -134,11 +134,8 @@ RUN apt-get -y install zlib1g-dev liblcms2-dev libwebp-dev libgeos-dev && \
     # Install basemap
     cd .. && python setup.py install && \
     pip install basemap --no-binary basemap
-
-RUN cd /usr/local/src && git clone https://github.com/vitruvianscience/opendeep.git && \
-    cd opendeep && python setup.py develop  && \
-    # sasl is apparently an ibis dependency
-    apt-get -y install libsasl2-dev && \
+# sasl is apparently an ibis dependency
+RUN apt-get -y install libsasl2-dev && \
     # ...as is psycopg2
     apt-get install -y libpq-dev && \
     pip install ibis-framework && \


### PR DESCRIPTION
The package was broken for quite a while and no user noticed/complained. 

The last update on github for this package was 3 years ago and the package is still marked as an alpha and in active development, which is clearly not the case.