### PR TITLE
only install packages after downgrading to python 3.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,14 @@ RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list &
     pip install --upgrade pip && \
     apt-get -y install cmake
 
+# Tensorflow doesn't support python 3.7 yet. See https://github.com/tensorflow/tensorflow/issues/20517
+# Fix to install tf 1.10:: Downgrade python 3.7->3.6.6 and downgrade Pandas 0.23.3->0.23.2
+RUN conda install -y python=3.6.6 && \
+    pip install pandas==0.23.2 && \
+    # Another fix for TF 1.10 https://github.com/tensorflow/tensorflow/issues/21518
+    pip install keras_applications==1.0.4 --no-deps && \
+    pip install keras_preprocessing==1.0.2 --no-deps
+
 RUN pip install seaborn python-dateutil dask pytagcloud pyyaml joblib \
     husl geopy ml_metrics mne pyshp && \
     conda install -y -c conda-forge spacy && python -m spacy download en && \
@@ -36,14 +44,6 @@ RUN pip install seaborn python-dateutil dask pytagcloud pyyaml joblib \
     make -j $(nproc) && make install && \
     # clean up ImageMagick source files
     cd ../ && rm -rf ImageMagick*
-
-# Tensorflow doesn't support python 3.7 yet. See https://github.com/tensorflow/tensorflow/issues/20517
-# Fix to install tf 1.10:: Downgrade python 3.7->3.6.6 and downgrade Pandas 0.23.3->0.23.2
-RUN conda install -y python=3.6.6 && \
-    pip install pandas==0.23.2 && \
-    # Another fix for TF 1.10 https://github.com/tensorflow/tensorflow/issues/21518
-    pip install keras_applications==1.0.4 --no-deps && \
-    pip install keras_preprocessing==1.0.2 --no-deps
 
 # Install tensorflow from a pre-built wheel
 COPY --from=tensorflow_whl /tmp/tensorflow_cpu/*.whl /tmp/tensorflow_cpu/


### PR DESCRIPTION
The packages we installed before we downgrade to 3.7 will be reinstalled for 3.6 but some of their settings or versions may not have been kept.

For instance, for the spacy package, we download the en_core_web_lg model. However, this model gets installed under /opt/conda/lib/python3.7/site-packages/ but later, spacy is reinstalled for 3.6. The result is that this model is not usuable but still present on the image.

To avoid these sorts of trouble, we should not install packages before we reinstall the python version we want.