### PR TITLE
Upgrade anaconda base to 5.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM gcr.io/kaggle-images/python-tensorflow-whl:1.11.0-py36 as tensorflow_whl
-FROM continuumio/anaconda3:5.0.1
+FROM continuumio/anaconda3:5.2.0
 
 # This is necessary for apt to access HTTPS sources
 RUN apt-get update && \
@@ -30,13 +30,13 @@ RUN pip install seaborn python-dateutil dask pytagcloud pyyaml joblib \
     conda install -y -c conda-forge spacy && python -m spacy download en && \
     python -m spacy download en_core_web_lg && \
     # The apt-get version of imagemagick is out of date and has compatibility issues, so we build from source
-    apt-get -y install dbus fontconfig fontconfig-config fonts-dejavu-core fonts-droid ghostscript gsfonts hicolor-icon-theme \
+    apt-get -y install dbus fontconfig fontconfig-config fonts-dejavu-core fonts-droid-fallback ghostscript gsfonts hicolor-icon-theme \
     libavahi-client3 libavahi-common-data libavahi-common3 libcairo2 libcap-ng0 libcroco3 \
     libcups2 libcupsfilters1 libcupsimage2 libdatrie1 libdbus-1-3 libdjvulibre-text libdjvulibre21 libfftw3-double3 libfontconfig1 \
     libfreetype6 libgdk-pixbuf2.0-0 libgdk-pixbuf2.0-common libgomp1 libgraphite2-3 libgs9 libgs9-common libharfbuzz0b libijs-0.35 \
-    libilmbase6 libjasper1 libjbig0 libjbig2dec0 libjpeg62-turbo liblcms2-2 liblqr-1-0 libltdl7 libmagickcore-6.q16-2 \
-    libmagickcore-6.q16-2-extra libmagickwand-6.q16-2 libnetpbm10 libopenexr6 libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0 \
-    libpaper-utils libpaper1 libpixman-1-0 libpng12-0 librsvg2-2 librsvg2-common libthai-data libthai0 libtiff5 libwmf0.2-7 \
+    libilmbase12 libjbig0 libjbig2dec0 libjpeg62-turbo liblcms2-2 liblqr-1-0 libltdl7 libmagickcore-6.q16-3 \
+    libmagickcore-6.q16-3-extra libmagickwand-6.q16-3 libnetpbm10 libopenexr22 libpango-1.0-0 libpangocairo-1.0-0 libpangoft2-1.0-0 \
+    libpaper-utils libpaper1 libpixman-1-0 libpng16-16 librsvg2-2 librsvg2-common libthai-data libthai0 libtiff5 libwmf0.2-7 \
     libxcb-render0 libxcb-shm0 netpbm poppler-data p7zip-full && \
     cd /usr/local/src && \
     wget http://transloadit.imagemagick.org/download/ImageMagick.tar.gz && \
@@ -126,13 +126,7 @@ RUN apt-get -y install zlib1g-dev liblcms2-dev libwebp-dev libgeos-dev && \
     cd /usr/local/src && git clone https://github.com/matplotlib/basemap.git && \
     cd basemap && \
     git checkout v1.1.0 && \
-    # Install geos
-    cd geos-3.3.3 && \
-    export GEOS_DIR=/usr/local && \
-    ./configure --prefix=$GEOS_DIR && \
-    make && make install && \
-    # Install basemap
-    cd .. && python setup.py install && \
+    python setup.py install && \
     pip install basemap --no-binary basemap
 
 # sasl is apparently an ibis dependency


### PR DESCRIPTION
* geos is now installed using apt-get.
* this version of anaconda is based on debian 9 (as opposed to 8 currently). I updated several packages because the older version where not available for the newer debian
* removed libjasper (not maintained and not available anymore for debian 9), magick uses openjpeg library instead
