### PR TITLE
Install fasttext using pip git feature

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -341,7 +341,7 @@ RUN pip install --upgrade cython && \
     pip install --upgrade cysignals && \
     pip install pyfasttext && \
     pip install ktext && \
-    cd /usr/local/src && git clone --depth=1 https://github.com/facebookresearch/fastText.git && cd fastText && pip install . && \
+    pip install git+git://github.com/facebookresearch/fastText.git && \
     apt-get install -y libhunspell-dev && pip install hunspell && \
     pip install annoy && \
     pip install category_encoders && \


### PR DESCRIPTION
fasttext depends on pybind11. Using pip to install this package makes sure this dependency is satisfied.

Prior to this change, the build was failing with the following error:
```
Oct 25 13:07:46   ModuleNotFoundError: No module named 'pybind11'
```
-- https://ci.kaggle.net/job/docker-python/job/master/251/consoleText