### PR TITLE
Don't preload tensorflow and torch

### DIFF
--- a/patches/sitecustomize.py
+++ b/patches/sitecustomize.py
@@ -1,13 +1,6 @@
-# Monkey patches BigQuery client creation to use proxy.
-
-# Import tensorflow and torch before anything else. This is a hacky workaround to an error on dlopen
-# reporting a limit on static TLS, tracked in:
-# tensorflow: https://github.com/tensorflow/tensorflow/issues/19010
-# torch: https://github.com/pytorch/pytorch/issues/2575
-import tensorflow
-import torch
 import os
 
+# Monkey patches BigQuery client creation to use proxy.
 kaggle_proxy_token = os.getenv("KAGGLE_DATA_PROXY_TOKEN")
 if kaggle_proxy_token:
     from google.auth import credentials


### PR DESCRIPTION
A little while back, we had issue with hiting the size limit for loading object in static TLS (thread local storage). A workaround was to preload those libraries. Newer versions of these libraries and their dependencies reduce the use of static TLS.

Removing the preloading of these libraries will make using `pip install` and the like in kernels easier.

I ran our test suite and the kernel reported by a user originally that was causing TLS issue and they all run: https://www.kaggle.com/kmader/library-overload

BUG=118388247