### PR TITLE
Adding xvfb and xvfbwrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -210,6 +210,15 @@ RUN pip install scipy && \
     conda clean -i -l -t -y && \
     rm -rf /usr/local/src/*
 
+
+# xvfbwrapper with dependencies
+RUN apt-get install -y xvfb && \
+    pip install xvfbwrapper && \
+    # ~~~~ CLEAN UP ~~~~
+    rm -rf /root/.cache/pip/* && \
+    apt-get autoremove -y && apt-get clean
+
+
 RUN pip install --upgrade mpld3 && \
     pip install mplleaflet && \
     pip install gpxpy && \

--- a/tests/test_dipy.py
+++ b/tests/test_dipy.py
@@ -1,0 +1,19 @@
+import unittest
+import os.path
+from dipy.viz import window
+from xvfbwrapper import Xvfb
+
+class TestDipy(unittest.TestCase):
+    out_file = 'test.png'
+    def test_renderer(self):
+        vdisplay = Xvfb()
+        vdisplay.start()
+
+        ren = window.Renderer()
+        window.record(ren, n_frames=1, out_path=self.out_file, size=(600, 600))
+        self.assertTrue(os.path.exists(self.out_file))
+
+        vdisplay.stop()
+
+    def tearDown(self):
+        os.remove(self.out_file)

--- a/tests/test_xvfbwrapper.py
+++ b/tests/test_xvfbwrapper.py
@@ -1,0 +1,11 @@
+import unittest
+import os.path
+from xvfbwrapper import Xvfb
+
+class TestXvfbwrapper(unittest.TestCase):
+    def test_xvfb(self):
+        vdisplay = Xvfb()
+        vdisplay.start()
+        display_var = ':{}'.format(vdisplay.new_display)
+        self.assertEqual(display_var, os.environ['DISPLAY'])
+        vdisplay.stop()


### PR DESCRIPTION
Closes #359 by providing a workaround consisting of framebuffer X server that can be used to render visualizations offscreen on headless nodes. Example:

```
from dipy.viz import window
from xvfbwrapper import Xvfb

vdisplay = Xvfb()
vdisplay.start()

ren = window.Renderer()
window.record(ren, n_frames=1, out_path='test.png', size=(600, 600))

vdisplay.stop()
```

Ideally (from user convienience point of view) Xvfb should be started automatically via bash wrapper script set as an ENTRYPOINT, but that could lead to some unforseen side effects so I would suggest leaving this for another PR.