### PR TITLE
Pip install sastrawi and add test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -475,6 +475,7 @@ RUN pip install flashtext && \
     pip install PDPbox && \
     pip install ggplot && \
     pip install cesium && \
+    pip install sastrawi && \
     ##### ^^^^ Add new contributions above here ^^^^ #####
     # clean up pip cache
     rm -rf /root/.cache/pip/*

--- a/tests/test_sastrawi.py
+++ b/tests/test_sastrawi.py
@@ -1,0 +1,8 @@
+import unittest
+
+from Sastrawi.Stemmer.StemmerFactory import StemmerFactory
+
+class TestCartopy(unittest.TestCase):
+    def test_stem(self):
+        factory = StemmerFactory()
+				stemmer = factory.create_stemmer()

--- a/tests/test_sastrawi.py
+++ b/tests/test_sastrawi.py
@@ -5,4 +5,4 @@ from Sastrawi.Stemmer.StemmerFactory import StemmerFactory
 class TestCartopy(unittest.TestCase):
     def test_stem(self):
         factory = StemmerFactory()
-				stemmer = factory.create_stemmer()
+        stemmer = factory.create_stemmer()


### PR DESCRIPTION
Sastrawi Python is a simple python library which allows you to reduce inflected words in Indonesian Language (Bahasa Indonesia) to their base form (stem). This is Python port of the original Sastrawi project written in PHP (credits goes to the original author and contributors of Sastrawi PHP).