### PR TITLE
Preload tensorflow

### DIFF
--- a/patches/sitecustomize.py
+++ b/patches/sitecustomize.py
@@ -1,3 +1,5 @@
+# TODO(rosbo): Remove this once we fix the issue with fastai importing older libcudnn if imported prior to tensorflow
+import tensorflow
 import os
 
 # Monkey patches BigQuery client creation to use proxy.


### PR DESCRIPTION
If fastai is used prior to tensorflow, an older version of libcudnn is loaded and tensorflow fails with the following error message:
```
tensorflow/stream_executor/cuda/cuda_dnn.cc:343] Loaded runtime CuDNN library: 7.1.2 but source was compiled with: 7.2.1.  CuDNN library major and minor version needs to match or have higher minor version in case of CuDNN 7.0 or later version. If using a binary install, upgrade your CuDNN library.  If building from sources, make sure the library loaded at runtime is compatible with the version specified during compile configuration.
```

Preloading for now (like before) until we find how to fix the issue with fastai

This issue was caught by our test suite and wasn't released to Kaggle Kernels users.