### PR TITLE
Remove the kaggle api package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -475,7 +475,6 @@ RUN pip install flashtext && \
     pip install PDPbox && \
     pip install ggplot && \
     pip install cesium && \
-    pip install kaggle && \
     ##### ^^^^ Add new contributions above here ^^^^ #####
     # clean up pip cache
     rm -rf /root/.cache/pip/*


### PR DESCRIPTION
This breaks the twosigma competition because the code for both lives in a python package called `kaggle`.

The code for the twosigma competition under `kaggle.competitions` should probably be move.

Additionally, the kaggle api client package requires an API secret key. We don't offer a way to manage secrets for now and we don't want to encourage people adding their secret in the code (easy to leak if ever made public).