### PR TITLE
Push image to gcr.io even if tests fail

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,6 +29,18 @@ pipeline {
       }
     }
 
+    stage('Push CPU Untested Image') {
+      steps {
+        slackSend color: 'none', message: "*<${env.BUILD_URL}console|${JOB_NAME} pushing untested image>* ${GIT_COMMIT_SUMMARY}", channel: env.SLACK_CHANNEL
+        sh '''#!/bin/bash
+          set -exo pipefail
+
+          date
+          ./push ci-untested
+        '''
+      }
+    }
+
     stage('Test CPU Image') {
       steps {
         slackSend color: 'none', message: "*<${env.BUILD_URL}console|${JOB_NAME} test image>* ${GIT_COMMIT_SUMMARY}", channel: env.SLACK_CHANNEL
@@ -67,6 +79,19 @@ pipeline {
           set -exo pipefail
           docker image prune -a -f # remove previously built image to prevent disk from filling up
           ./build --gpu | ts
+        '''
+      }
+    }
+
+    stage('Push GPU Untested Image') {
+      agent { label 'ephemeral-linux-gpu' }
+      steps {
+        slackSend color: 'none', message: "*<${env.BUILD_URL}console|${JOB_NAME} pushing untested image>* ${GIT_COMMIT_SUMMARY}", channel: env.SLACK_CHANNEL
+        sh '''#!/bin/bash
+          set -exo pipefail
+
+          date
+          ./push --gpu ci-untested
         '''
       }
     }


### PR DESCRIPTION
The image is pushed to `gcr.io` before we run tests against it with the `ci-untested` label.
Once tests passed, the `staging` label is added to the image (we will change this tag to `ci` in the near future). 

This enable easy test failures debugging. No need to build the image locally, we just need to pull it from gcr.io and run the test locally to identify and fix the failure.