### PR TITLE
Add cupy and pynvrtc to GPU Dockerfile for custom networks in CUDA

### DIFF
--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -54,4 +54,6 @@ RUN pip uninstall -y tensorflow && \
 
 # Install GPU-only packages
 RUN pip install pycuda && \
+    pip install cupy-cuda91 && \
+    pip install pynvrtc && \
     /tmp/clean-layer.sh

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -54,6 +54,6 @@ RUN pip uninstall -y tensorflow && \
 
 # Install GPU-only packages
 RUN pip install pycuda && \
-    pip install cupy-cuda91 && \
+    pip install cupy-cuda92 && \
     pip install pynvrtc && \
     /tmp/clean-layer.sh


### PR DESCRIPTION
From @guitarmind,

I'm participating [Quora Insincere Questions Classification](https://www.kaggle.com/c/quora-insincere-questions-classification) competition right now and it is limited to provide only 2-CPUs, 14GB RAM and a K80 GPU in 2 hours kernel run time. Therefore it is crucial for kagglers to be able to utilize CUDA library and its interfaces to build performant custom networks in Tensorflow or PyTorch under such limited resources.

[cupy](https://github.com/cupy/cupy) and [pynvrtc](pynvrtc) are commonly required packages.
Some examples about their usage:

- `Quasi-Recurrent Neural Networks` ([QRNN](https://github.com/salesforce/pytorch-qrnn))
- `Independently Recurrent Neural Networks` ([IndRNN](https://github.com/Sunnydreamrain/IndRNN_pytorch))

I've built it successfully by following your instruction in the README.
That would be appreciated if you could help merge it!
Also feel free to let me know if any changes required to improve this PR, thanks!

