### PR TITLE
Adding pytext-nlp to the kernel image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -473,6 +473,7 @@ RUN pip install flashtext && \
     pip install ggplot && \
     pip install cesium && \
     pip install rgf_python && \
+    pip install pytext-nlp && \
     /tmp/clean-layer.sh
 
 # Pin Vowpal Wabbit v8.6.0 because 8.6.1 does not build or install successfully

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To get started with this image, read our [guide](http://blog.kaggle.com/2016/02/
 
 ## Requesting new packages
 
-First, evaluate whether installing the package yourself in your own Kernels suits your needs. See [guide](wiki/Missing-Packages).
+First, evaluate whether installing the package yourself in your own Kernels suits your needs. See [guide](https://github.com/Kaggle/docker-python/wiki/Missing-Packages).
 
 If you the first step above doesn't work for your use case, [open an issue](https://github.com/Kaggle/docker-python/issues/new) or a [pull request](https://github.com/Kaggle/docker-python/pulls).
 

--- a/tests/test_pytext.py
+++ b/tests/test_pytext.py
@@ -1,0 +1,14 @@
+import unittest
+
+from pytext.config.field_config import FeatureConfig
+from pytext.data.featurizer import InputRecord, SimpleFeaturizer
+
+class TestPyText(unittest.TestCase):
+
+    def test_tokenize(self):
+        featurizer = SimpleFeaturizer.from_config(
+            SimpleFeaturizer.Config(), FeatureConfig()
+        )
+
+        tokens = featurizer.featurize(InputRecord(raw_text="At eight o'clock")).tokens
+        self.assertEqual(['at', 'eight', "o'clock"], tokens)


### PR DESCRIPTION
PyText has recently been open sourced by Facebook to enable faster NLP experimentation: 
https://code.fb.com/ai-research/pytext-open-source-nlp-framework/

It's likely to be super useful for all NLP competitions, such as the current Quora one:
https://www.kaggle.com/c/quora-insincere-questions-classification

Specifically, the Quora competition is a kernel submissions only *and* we cannot use internet connection enabled kernels, which is what brought me here. 

I've added the `pip install pytext-nlp` to the `Dockerfile`.

Also, I've fixed a broken URL in the `README` -- the guide was giving a 404.
