### PR TITLE
Pin numpy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,8 +143,9 @@ RUN apt-get -y install zlib1g-dev liblcms2-dev libwebp-dev libgeos-dev && \
     # MXNet
     pip install mxnet && \
     # h2o (requires java)
-    # Upgrade numpy with pip to avoid install errors
-    pip install --upgrade numpy && \
+    # Some packages such as sk_image are not compatible with the 1.16 version yet.
+    # See: https://github.com/scikit-image/scikit-image/issues/3551
+    pip install numpy==1.15.4 && \
     # requires java
     apt-get install -y default-jdk && \
     cd /usr/local/src && mkdir h2o && cd h2o && \
@@ -404,7 +405,6 @@ RUN pip install bcolz && \
     pip install nbconvert && \
     pip install nbformat && \
     pip install notebook==5.5.0 && \
-    pip install numpy && \
     pip install olefile && \
     pip install opencv-python && \
     pip install --upgrade pandas && \


### PR DESCRIPTION
skimage is not compatible with the latest version of numpy (1.16) yet. Pining numpy to the 1.15 version for now.