### PR TITLE
pin fitter to 1.0.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -239,7 +239,10 @@ RUN pip install --upgrade mpld3 && \
     pip install git+https://github.com/hyperopt/hyperopt.git && \
     # tflean. Deep learning library featuring a higher-level API for TensorFlow. http://tflearn.org
     pip install git+https://github.com/tflearn/tflearn.git && \
-    pip install fitter && \
+    # fitter 1.1.10 is broken. Fails at setup with:
+    # install_requires = open("requirements.txt").read(),
+    # FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
+    pip install fitter==1.0.9 && \
     pip install langid && \
     # Delorean. Useful for dealing with datetime
     pip install delorean && \


### PR DESCRIPTION
fitter 1.1.10 is broken. Fails at setup with:
```
Jan 30 02:16:32     Complete output from command python setup.py egg_info:
Jan 30 02:16:32     Traceback (most recent call last):
Jan 30 02:16:32       File "<string>", line 1, in <module>
Jan 30 02:16:32       File "/tmp/pip-install-53f2_u7d/fitter/setup.py", line 54, in <module>
Jan 30 02:16:32         install_requires = open("requirements.txt").read(),
Jan 30 02:16:32     FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
```