### PR TITLE
Add MXNet GPU + GluonNLP and GluonCV toolkits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -141,6 +141,8 @@ RUN apt-get -y install zlib1g-dev liblcms2-dev libwebp-dev libgeos-dev && \
     # MXNet
     pip install mxnet && \
     pip install --upgrade numpy && \
+    pip install gluonnlp && \
+    pip install gluoncv && \
     # h2o (requires java)
     # requires java
     apt-get install -y default-jdk && \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -52,8 +52,8 @@ RUN pip uninstall -y tensorflow && \
     conda install -y pytorch torchvision -c pytorch && \
     /tmp/clean-layer.sh
 
-RUN pip uninstall -y mxnet &&
-    pip install mxnet-cu92mkl
+RUN pip uninstall -y mxnet && \
+    pip install mxnet-cu92
 
 # Install GPU-only packages
 RUN pip install pycuda && \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -52,6 +52,9 @@ RUN pip uninstall -y tensorflow && \
     conda install -y pytorch torchvision -c pytorch && \
     /tmp/clean-layer.sh
 
+RUN pip uninstall -y mxnet &&
+    pip install mxnet-cu92mkl
+
 # Install GPU-only packages
 RUN pip install pycuda && \
     pip install cupy-cuda92 && \

--- a/tests/test_mxnet.py
+++ b/tests/test_mxnet.py
@@ -1,0 +1,37 @@
+import unittest
+from common import gpu_test
+
+import mxnet as mx
+from gluonnlp import Vocab
+from gluonnlp.data import count_tokens
+
+from gluoncv.data.transforms.image import imresize
+
+
+class TestMxNet(unittest.TestCase):
+    def test_array(self):    
+        x = mx.nd.array([[1, 2, 3], [4, 5, 6]])
+
+        self.assertEqual((2, 3), x.shape)
+
+    @gpu_test
+    def test_array_gpu(self):
+        x = mx.nd.array([2, 2, 2], ctx=mx.gpu(0))
+        y = mx.nd.array([1, 1, 1], ctx=mx.gpu(0))
+        self.assertEqual(3, ((x - y).sum().asscalar()))
+
+    def test_gluon_nlp(self):
+        # get corpus statistics
+        counter = count_tokens(['alpha', 'beta', 'gamma', 'beta'])
+        # create Vocab
+        vocab = Vocab(counter)
+        # find index based on token
+        self.assertEqual(4, vocab['beta'])
+
+    def test_gluon_cv(self):
+        # create fake RGB image of 300x300 of shape: Height x Width x Channel as OpenCV expects
+        img = mx.random.uniform(0, 255, (300, 300, 3)).astype('uint8')
+        # resize image to 200x200. This call uses OpenCV
+        # GluonCV is not of much use if OpenCV is not there or fails
+        img = imresize(img, 200, 200)
+        self.assertEqual((200, 200, 3), img.shape)

--- a/tests/text_mxnet.py
+++ b/tests/text_mxnet.py
@@ -1,9 +1,0 @@
-import unittest
-
-import mxnet as mx
-
-class TestMxNet(unittest.TestCase):
-    def test_array(self):    
-        x = mx.nd.array([[1, 2, 3], [4, 5, 6]])
-
-        self.assertEqual((2, 3), x.shape)


### PR DESCRIPTION
This pull request adds GPU version of MXNet to GPU kernel + GluonNLP and GluonCV toolkits to both kernels.

I use pure (not MKL version) of MXNet in case MKL is not supported on the host.
I use CUDA 9.2 version, as I see other packages of GPU kernel relies on 9.2 version of CUDA. Feel free to change to MKL versions if it is guaranteed to present on the host: `mxnet-mkl` and `mxnet-cu92mkl` packages for CPU and GPU respectively.

Relates to https://github.com/Kaggle/docker-python/issues/452
@rosbo, thanks for fixing the master!