### PR TITLE
Add optuna and tests.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -480,6 +480,7 @@ RUN pip install flashtext && \
     pip install tsfresh && \
     pip install pymagnitude && \
     pip install pykalman && \
+    pip install optuna && \
     /tmp/clean-layer.sh
 
 # Pin Vowpal Wabbit v8.6.0 because 8.6.1 does not build or install successfully

--- a/tests/test_optuna.py
+++ b/tests/test_optuna.py
@@ -1,0 +1,17 @@
+import unittest
+
+import optuna
+
+
+class TestOptuna(unittest.TestCase):
+
+    def test_study(self):
+
+        def objective(trial):
+            x = trial.suggest_uniform('x', -1., 1.)
+            return x ** 2
+
+        n_trials = 20
+        study = optuna.create_study()
+        study.optimize(objective, n_trials=n_trials)
+        self.assertEqual(len(study.trials), n_trials)


### PR DESCRIPTION
This PR adds [optuna](https://optuna.org/), which is an automatic hyperparameter optimization framework, particularly designed for Machine Learning. 

Although a similar request can be seen in PR #411, it has not shown any progress for several months.
So, I would like to create this request to add optuna as a new PR.

I confirmed that both `./build` and `./test` worked fine in my local machine.