### PR TITLE
Move JWE to request body instead of header.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM gcr.io/kaggle-images/python-tensorflow-whl:1.12.0-py36 as tensorflow_whl
 FROM continuumio/anaconda3:5.2.0
 
 ADD clean-layer.sh  /tmp/clean-layer.sh
-ADD patches/ /tmp/patches/
 ADD patches/nbconvert-extensions.tpl /opt/kaggle/nbconvert-extensions.tpl
 
 # This is necessary for apt to access HTTPS sources

--- a/patches/kaggle_secrets.py
+++ b/patches/kaggle_secrets.py
@@ -29,16 +29,17 @@ class UserSecretsClient():
         url_base_override = os.getenv(_KAGGLE_URL_BASE_ENV_VAR_NAME)
         self.url_base = url_base_override or _KAGGLE_DEFAULT_URL_BASE
         # Follow the OAuth 2.0 Authorization standard (https://tools.ietf.org/html/rfc6750)
-        jwt_token = os.getenv(_KAGGLE_USER_SECRETS_TOKEN_ENV_VAR_NAME)
-        if jwt_token is None:
+        self.jwt_token = os.getenv(_KAGGLE_USER_SECRETS_TOKEN_ENV_VAR_NAME)
+        if self.jwt_token is None:
             raise CredentialError(
                 'A JWT Token is required to use the UserSecretsClient, '
                 f'but none found in environment variable {_KAGGLE_USER_SECRETS_TOKEN_ENV_VAR_NAME}')
-        self.headers = {'Content-type': 'application/json',
-                        'Authorization': 'Bearer {}'.format(jwt_token)}
+        self.headers = {'Content-type': 'application/json'}
 
-    def _make_post_request(self, request_body):
+    def _make_post_request(self, data):
         url = f'{self.url_base}{self.GET_USER_SECRET_ENDPOINT}'
+        request_body = dict(data)
+        request_body['JWE'] = self.jwt_token
         req = urllib.request.Request(url, headers=self.headers, data=bytes(
             json.dumps(request_body), encoding="utf-8"))
         try:

--- a/tests/test_user_secrets.py
+++ b/tests/test_user_secrets.py
@@ -71,11 +71,6 @@ class TestUserSecrets(unittest.TestCase):
                     body,
                     expected_body,
                     msg="Fake server did not receive the right body from the UserSecrets client.")
-                self.assertTrue(
-                    any(
-                        k for k in headers
-                        if k == "Authorization" and headers[k] == f'Bearer {_TEST_JWT}'),
-                    msg="Authorization header was missing from the UserSecrets request.")
 
     def test_no_token_fails(self):
         env = EnvironmentVarGuard()
@@ -92,4 +87,4 @@ class TestUserSecrets(unittest.TestCase):
             secret_response = client.get_bigquery_access_token()
             self.assertEqual(secret_response, secret)
         self._test_client(call_get_access_token,
-                          '/requests/GetUserSecretRequest', {'Target': 1}, secret)
+                          '/requests/GetUserSecretRequest', {'Target': 1, 'JWE': _TEST_JWT}, secret)


### PR DESCRIPTION
We're moving the JWT to the body from the header, as the current Mediator framework in the Web Tier doesn't pass headers to the Service/Controllers. 