### PR TITLE
Properly store access token so it can be used by credentials object.

### DIFF
--- a/patches/kaggle_gcp.py
+++ b/patches/kaggle_gcp.py
@@ -14,10 +14,9 @@ class KaggleKernelCredentials(credentials.Credentials):
     """
 
     def refresh(self, request):
-        print("Calling Kaggle.UserSecrets to refresh token.")
         try:
             client = UserSecretsClient()
-            fresh_token = client.get_bigquery_access_token()
+            self.token = client.get_bigquery_access_token()
         except Exception as e:
             raise RefreshError('Unable to refresh access token.') from e
 


### PR DESCRIPTION
https://github.com/googleapis/google-auth-library-python/blob/master/google/auth/credentials.py#L45
