### PR TITLE
Upgrade to cuda 10.0 and Tensorflow 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_TAG=5.2.0
 
-FROM gcr.io/kaggle-images/python-tensorflow-whl:1.12.0-py36 as tensorflow_whl
+FROM gcr.io/kaggle-images/python-tensorflow-whl:1.13.1-py36 as tensorflow_whl
 FROM continuumio/anaconda3:${BASE_TAG}
 
 ADD clean-layer.sh  /tmp/clean-layer.sh
@@ -19,6 +19,11 @@ RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list &
     conda update -y conda && conda update -y python && \
     pip install pip==19.0.3 && \
     apt-get -y install cmake && \
+    /tmp/clean-layer.sh
+
+# Tensorflow doesn't support python 3.7 yet. See https://github.com/tensorflow/tensorflow/issues/20517	
+# Fix to install Tensorflow: Downgrade python 3.7->3.6.6.
+RUN conda install -y python=3.6.6 && \
     /tmp/clean-layer.sh
 
 # The anaconda base image includes outdated versions of these packages. Update them to include the latest version.

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,6 @@ RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list &
     apt-get -y install cmake && \
     /tmp/clean-layer.sh
 
-# Tensorflow doesn't support python 3.7 yet. See https://github.com/tensorflow/tensorflow/issues/20517
-# Fix to install Tensorflow: Downgrade python 3.7->3.6.6.
-RUN conda install -y python=3.6.6 && \
-    /tmp/clean-layer.sh
-
 # The anaconda base image includes outdated versions of these packages. Update them to include the latest version.
 RUN pip install --upgrade seaborn python-dateutil dask && \
     pip install pyyaml joblib pytagcloud husl geopy ml_metrics mne pyshp && \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -36,8 +36,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       cuda-nvml-dev-$CUDA_PKG_VERSION \
       cuda-minimal-build-$CUDA_PKG_VERSION \
       cuda-command-line-tools-$CUDA_PKG_VERSION \
-      libcudnn7=7.5.0.56-1+cuda10.0 \
-      libcudnn7-dev=7.5.0.56-1+cuda10.0 \
+      libcudnn7=7.4.2.24-1+cuda10.0 \
+      libcudnn7-dev=7.4.2.24-1+cuda10.0 \
       libnccl2=2.4.2-1+cuda10.0 \
       libnccl-dev=2.4.2-1+cuda10.0 && \
     ln -s /usr/local/cuda-10.0 /usr/local/cuda && \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_TAG=staging
 
 FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04 AS nvidia
-FROM gcr.io/kaggle-images/python-tensorflow-whl:1.12.0-py36 as tensorflow_whl
+FROM gcr.io/kaggle-images/python-tensorflow-whl:1.13.1-py36 as tensorflow_whl
 FROM gcr.io/kaggle-images/python:${BASE_TAG}
 
 ADD clean-layer.sh  /tmp/clean-layer.sh
@@ -13,8 +13,8 @@ COPY --from=nvidia /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/cuda.gpg
 
 # Ensure the cuda libraries are compatible with the custom Tensorflow wheels.
 # TODO(b/120050292): Use templating to keep in sync or COPY installed binaries from it.
-ENV CUDA_VERSION=9.2.148
-ENV CUDA_PKG_VERSION=9-2=$CUDA_VERSION-1
+ENV CUDA_VERSION=10.1.105
+ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
@@ -26,7 +26,7 @@ ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH="/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs"
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
-ENV NVIDIA_REQUIRE_CUDA="cuda>=9.2"
+ENV NVIDIA_REQUIRE_CUDA="cuda>=10.1"
 RUN apt-get update && apt-get install -y --no-install-recommends \
       cuda-cupti-$CUDA_PKG_VERSION \
       cuda-cudart-$CUDA_PKG_VERSION \
@@ -36,13 +36,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       cuda-nvml-dev-$CUDA_PKG_VERSION \
       cuda-minimal-build-$CUDA_PKG_VERSION \
       cuda-command-line-tools-$CUDA_PKG_VERSION \
-      libcudnn7=7.4.1.5-1+cuda9.2 \
-      libcudnn7-dev=7.4.1.5-1+cuda9.2 \
-      libnccl2=2.3.7-1+cuda9.2 \
-      libnccl-dev=2.3.7-1+cuda9.2 && \
-    ln -s /usr/local/cuda-9.2 /usr/local/cuda && \
+      libcudnn7=7.5.0.56-1+cuda10.1 \
+      libcudnn7-dev=7.5.0.56-1+cuda10.1 \
+      libnccl2=2.4.2-1+cuda10.1 \
+      libnccl-dev=2.4.2-1+cuda10.1 && \
+    ln -s /usr/local/cuda-10.1 /usr/local/cuda && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     /tmp/clean-layer.sh
+
+# TODO(rosbo): given tha pytorch and mxnet and cupy don't have cuda 10.1 versions.
+# Consider installing cuda 10.0
 
 # Reinstall packages with a separate version for GPU support
 # Tensorflow
@@ -51,15 +54,15 @@ RUN pip uninstall -y tensorflow && \
     pip install /tmp/tensorflow_gpu/tensorflow*.whl && \
     rm -rf /tmp/tensorflow_gpu && \
     conda uninstall -y pytorch-cpu torchvision-cpu && \
-    conda install -y pytorch torchvision cudatoolkit=9.2 -c pytorch && \
+    conda install -y pytorch torchvision cudatoolkit=10.0 -c pytorch && \
     pip uninstall -y mxnet && \
     # b/126259508 --no-deps prevents numpy from being downgraded.
-    pip install --no-deps mxnet-cu92 && \
+    pip install --no-deps mxnet-cu100 && \
     /tmp/clean-layer.sh
 
 # Install GPU-only packages
 RUN pip install pycuda && \
-    pip install cupy-cuda92 && \
+    pip install cupy-cuda100 && \
     pip install pynvrtc && \
     /tmp/clean-layer.sh
 

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -13,8 +13,8 @@ COPY --from=nvidia /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/cuda.gpg
 
 # Ensure the cuda libraries are compatible with the custom Tensorflow wheels.
 # TODO(b/120050292): Use templating to keep in sync or COPY installed binaries from it.
-ENV CUDA_VERSION=10.1.105
-ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1
+ENV CUDA_VERSION=10.0.130
+ENV CUDA_PKG_VERSION=10-0=$CUDA_VERSION-1
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
@@ -26,7 +26,7 @@ ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH="/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs"
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
-ENV NVIDIA_REQUIRE_CUDA="cuda>=10.1"
+ENV NVIDIA_REQUIRE_CUDA="cuda>=10.0"
 RUN apt-get update && apt-get install -y --no-install-recommends \
       cuda-cupti-$CUDA_PKG_VERSION \
       cuda-cudart-$CUDA_PKG_VERSION \
@@ -36,16 +36,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       cuda-nvml-dev-$CUDA_PKG_VERSION \
       cuda-minimal-build-$CUDA_PKG_VERSION \
       cuda-command-line-tools-$CUDA_PKG_VERSION \
-      libcudnn7=7.5.0.56-1+cuda10.1 \
-      libcudnn7-dev=7.5.0.56-1+cuda10.1 \
-      libnccl2=2.4.2-1+cuda10.1 \
-      libnccl-dev=2.4.2-1+cuda10.1 && \
-    ln -s /usr/local/cuda-10.1 /usr/local/cuda && \
+      libcudnn7=7.5.0.56-1+cuda10.0 \
+      libcudnn7-dev=7.5.0.56-1+cuda10.0 \
+      libnccl2=2.4.2-1+cuda10.0 \
+      libnccl-dev=2.4.2-1+cuda10.0 && \
+    ln -s /usr/local/cuda-10.0 /usr/local/cuda && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     /tmp/clean-layer.sh
-
-# TODO(rosbo): given tha pytorch and mxnet and cupy don't have cuda 10.1 versions.
-# Consider installing cuda 10.0
 
 # Reinstall packages with a separate version for GPU support
 # Tensorflow

--- a/tensorflow-whl/CHANGELOG.md
+++ b/tensorflow-whl/CHANGELOG.md
@@ -1,3 +1,3 @@
 1.11.0-py36: Tensorflow 1.11.0 wheels built with python 3.6
 1.12.0-py36: Tensorflow 1.12.0 wheels with Cuda 9.2
-1.13.1-py36: Tensorflow 1.13.1 wheels with Cuda 10.1
+1.13.1-py36: Tensorflow 1.13.1 wheels with Cuda 10.0

--- a/tensorflow-whl/CHANGELOG.md
+++ b/tensorflow-whl/CHANGELOG.md
@@ -1,2 +1,3 @@
 1.11.0-py36: Tensorflow 1.11.0 wheels built with python 3.6
 1.12.0-py36: Tensorflow 1.12.0 wheels with Cuda 9.2
+1.13.1-py36: Tensorflow 1.13.1 wheels with Cuda 10.1

--- a/tensorflow-whl/Dockerfile
+++ b/tensorflow-whl/Dockerfile
@@ -28,7 +28,7 @@ ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs"
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
-ENV NVIDIA_REQUIRE_CUDA="cuda>=9.0"
+ENV NVIDIA_REQUIRE_CUDA="cuda>=10.1"
 RUN apt-get update && apt-get install -y --no-install-recommends \
       cuda-cupti-$CUDA_PKG_VERSION \
       cuda-cudart-$CUDA_PKG_VERSION \
@@ -49,7 +49,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Install bazel
 # Tensorflow 1.13 requires the Bazel 0.19.2: https://www.tensorflow.org/install/source
 ENV BAZEL_VERSION=0.19.2
-RUN apt-get update && apt-get install -y gnupg zip && \
+RUN apt-get install -y gnupg zip && \
     echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu precise main" | tee -a /etc/apt/sources.list && \
     echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu precise main" | tee -a /etc/apt/sources.list && \
     apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys --no-tty EEA14886 C857C906 2B90D010 && \
@@ -65,14 +65,13 @@ RUN apt-get update && apt-get install -y gnupg zip && \
     dpkg -i bazel_*.deb && \
     rm bazel_*.deb
 
-# Tensorflow doesn't support python 3.7 yet. See https://github.com/tensorflow/tensorflow/issues/20517
-RUN conda install -y python=3.6.6
-
-# Fetch tensorflow
+# Fetch tensorflow & install dependencies.
 RUN cd /usr/local/src && \
     git clone https://github.com/tensorflow/tensorflow && \
     cd tensorflow && \
-    git checkout r1.13
+    git checkout r1.13 && \
+    pip install keras_applications --no-deps && \
+    pip install keras_preprocessing --no-deps
 
 # Create a tensorflow wheel for CPU
 RUN cd /usr/local/src/tensorflow && \

--- a/tensorflow-whl/Dockerfile
+++ b/tensorflow-whl/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:9.2-cudnn7-devel-ubuntu16.04 AS nvidia
+FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04 AS nvidia
 FROM continuumio/anaconda3:5.2.0
 
 # Avoid interactive configuration prompts/dialogs during apt-get.
@@ -15,8 +15,8 @@ COPY --from=nvidia /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/cuda.gpg
 
 # Ensure the cuda libraries are compatible with the GPU image.
 # TODO(b/120050292): Use templating to keep in sync.
-ENV CUDA_VERSION=9.2.148
-ENV CUDA_PKG_VERSION=9-2=$CUDA_VERSION-1
+ENV CUDA_VERSION=10.1.105
+ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
@@ -38,17 +38,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       cuda-nvml-dev-$CUDA_PKG_VERSION \
       cuda-minimal-build-$CUDA_PKG_VERSION \
       cuda-command-line-tools-$CUDA_PKG_VERSION \
-      libcudnn7=7.4.1.5-1+cuda9.2 \
-      libcudnn7-dev=7.4.1.5-1+cuda9.2 \
-      libnccl2=2.3.7-1+cuda9.2 \
-      libnccl-dev=2.3.7-1+cuda9.2 && \
-    ln -s /usr/local/cuda-9.2 /usr/local/cuda && \
+      libcudnn7=7.5.0.56-1+cuda10.1 \
+      libcudnn7-dev=7.5.0.56-1+cuda10.1 \
+      libnccl2=2.4.2-1+cuda10.1 \
+      libnccl-dev=2.4.2-1+cuda10.1 && \
+    ln -s /usr/local/cuda-10.1 /usr/local/cuda && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     rm -rf /var/lib/apt/lists/*
 
 # Install bazel
-# Tensorflow 1.11 requires the Bazel 0.15: https://www.tensorflow.org/install/source
-ENV BAZEL_VERSION=0.15.0
+# Tensorflow 1.13 requires the Bazel 0.19.2: https://www.tensorflow.org/install/source
+ENV BAZEL_VERSION=0.19.2
 RUN apt-get update && apt-get install -y gnupg zip && \
     echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu precise main" | tee -a /etc/apt/sources.list && \
     echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu precise main" | tee -a /etc/apt/sources.list && \
@@ -72,7 +72,7 @@ RUN conda install -y python=3.6.6
 RUN cd /usr/local/src && \
     git clone https://github.com/tensorflow/tensorflow && \
     cd tensorflow && \
-    git checkout r1.12
+    git checkout r1.13
 
 # Create a tensorflow wheel for CPU
 RUN cd /usr/local/src/tensorflow && \
@@ -83,9 +83,9 @@ RUN cd /usr/local/src/tensorflow && \
 
 # Create a tensorflow wheel for GPU/cuda
 ENV TF_NEED_CUDA=1
-ENV TF_CUDA_VERSION=9.2
-# 3.7 is for the K80 and 6.0 is for the P100: https://developer.nvidia.com/cuda-gpus
-ENV TF_CUDA_COMPUTE_CAPABILITIES=3.7,6.0
+ENV TF_CUDA_VERSION=10.1
+# 3.7 is for the K80 and 6.0 is for the P100, 7.5 is for the T4: https://developer.nvidia.com/cuda-gpus
+ENV TF_CUDA_COMPUTE_CAPABILITIES=3.7,6.0,7.5
 ENV TF_CUDNN_VERSION=7
 ENV TF_NCCL_VERSION=2
 ENV NCCL_INSTALL_PATH=/usr/

--- a/tensorflow-whl/Dockerfile
+++ b/tensorflow-whl/Dockerfile
@@ -64,6 +64,9 @@ RUN apt-get install -y gnupg zip && \
     dpkg -i bazel_*.deb && \
     rm bazel_*.deb
 
+# Tensorflow doesn't support python 3.7 yet. See https://github.com/tensorflow/tensorflow/issues/20517
+RUN conda install -y python=3.6.6
+
 # Fetch tensorflow & install dependencies.
 RUN cd /usr/local/src && \
     git clone https://github.com/tensorflow/tensorflow && \

--- a/tensorflow-whl/Dockerfile
+++ b/tensorflow-whl/Dockerfile
@@ -43,8 +43,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       libnccl2=2.4.2-1+cuda10.0 \
       libnccl-dev=2.4.2-1+cuda10.0 && \
     ln -s /usr/local/cuda-10.0 /usr/local/cuda && \
-    ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
-    rm -rf /var/lib/apt/lists/*
+    ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 
 # Install bazel
 # Tensorflow 1.13 requires the Bazel 0.19.2: https://www.tensorflow.org/install/source

--- a/tensorflow-whl/Dockerfile
+++ b/tensorflow-whl/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04 AS nvidia
+FROM nvidia/cuda:10.0-cudnn7-devel-ubuntu16.04 AS nvidia
 FROM continuumio/anaconda3:5.2.0
 
 # Avoid interactive configuration prompts/dialogs during apt-get.
@@ -15,8 +15,8 @@ COPY --from=nvidia /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/cuda.gpg
 
 # Ensure the cuda libraries are compatible with the GPU image.
 # TODO(b/120050292): Use templating to keep in sync.
-ENV CUDA_VERSION=10.1.105
-ENV CUDA_PKG_VERSION=10-1=$CUDA_VERSION-1
+ENV CUDA_VERSION=10.0.130
+ENV CUDA_PKG_VERSION=10-0=$CUDA_VERSION-1
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
@@ -28,7 +28,7 @@ ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 ENV LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/nvidia/lib64:/usr/local/cuda/lib64:/usr/local/cuda/lib64/stubs"
 ENV NVIDIA_VISIBLE_DEVICES=all
 ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
-ENV NVIDIA_REQUIRE_CUDA="cuda>=10.1"
+ENV NVIDIA_REQUIRE_CUDA="cuda>=10.0"
 RUN apt-get update && apt-get install -y --no-install-recommends \
       cuda-cupti-$CUDA_PKG_VERSION \
       cuda-cudart-$CUDA_PKG_VERSION \
@@ -38,11 +38,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       cuda-nvml-dev-$CUDA_PKG_VERSION \
       cuda-minimal-build-$CUDA_PKG_VERSION \
       cuda-command-line-tools-$CUDA_PKG_VERSION \
-      libcudnn7=7.5.0.56-1+cuda10.1 \
-      libcudnn7-dev=7.5.0.56-1+cuda10.1 \
-      libnccl2=2.4.2-1+cuda10.1 \
-      libnccl-dev=2.4.2-1+cuda10.1 && \
-    ln -s /usr/local/cuda-10.1 /usr/local/cuda && \
+      libcudnn7=7.5.0.56-1+cuda10.0 \
+      libcudnn7-dev=7.5.0.56-1+cuda10.0 \
+      libnccl2=2.4.2-1+cuda10.0 \
+      libnccl-dev=2.4.2-1+cuda10.0 && \
+    ln -s /usr/local/cuda-10.0 /usr/local/cuda && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1 && \
     rm -rf /var/lib/apt/lists/*
 
@@ -82,7 +82,7 @@ RUN cd /usr/local/src/tensorflow && \
 
 # Create a tensorflow wheel for GPU/cuda
 ENV TF_NEED_CUDA=1
-ENV TF_CUDA_VERSION=10.1
+ENV TF_CUDA_VERSION=10.0
 # 3.7 is for the K80 and 6.0 is for the P100, 7.5 is for the T4: https://developer.nvidia.com/cuda-gpus
 ENV TF_CUDA_COMPUTE_CAPABILITIES=3.7,6.0,7.5
 ENV TF_CUDNN_VERSION=7


### PR DESCRIPTION
Note: The tensorflow wheel is built in a separate pipeline to reduce build time in the main pipeline. See go/kkb-python-image-build for more info on the build process.

The build succeeded: https://ci.kaggle.net/job/kernels/job/docker-python/job/upgrade-tf-cuda-ci/7/

BUG=125933441