### PR TITLE
Added support for args and kwargs when using the public bigquery proxy

### DIFF
--- a/patches/kaggle_gcp.py
+++ b/patches/kaggle_gcp.py
@@ -57,12 +57,12 @@ class PublicBigqueryClient(bigquery.client.Client):
     client = PublicBigqueryClient()
     """
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         data_proxy_project = os.getenv("KAGGLE_DATA_PROXY_PROJECT")
         anon_credentials = credentials.AnonymousCredentials()
         anon_credentials.refresh = lambda *args: None
         super().__init__(
-            project=data_proxy_project, credentials=anon_credentials
+            project=data_proxy_project, credentials=anon_credentials, *args, **kwargs
         )
         # TODO: Remove this once https://github.com/googleapis/google-cloud-python/issues/7122 is implemented.
         self._connection = _DataProxyConnection(self)

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -56,6 +56,13 @@ class TestBigQuery(unittest.TestCase):
             client = bigquery.Client()
             self._test_proxy(client, should_use_proxy=True)
 
+    def test_proxy_with_kwargs(self):
+        env = EnvironmentVarGuard()
+        env.unset('KAGGLE_BQ_USER_JWT')
+        with env:
+            client = bigquery.Client(default_query_job_config=bigquery.QueryJobConfig(maximum_bytes_billed=1e9))
+            self._test_proxy(client, should_use_proxy=True)
+
     def test_project_with_connected_account(self):
         env = EnvironmentVarGuard()
         env.set('KAGGLE_BQ_USER_JWT', 'foobar')


### PR DESCRIPTION
Title should be fairly self explanatory but our primary goal is to be able to pass in a default job config to the public bigquery client. This is my first time releasing code for docker-python but I ran build and test and everything seemed good. Please LMK if this doesn't meet standards in any way or if there's anything else I need to adjust here.