### PR TITLE
Fix unit tests failing from headers missing, due to an update in bigq…

### DIFF
--- a/patches/kaggle_gcp.py
+++ b/patches/kaggle_gcp.py
@@ -53,7 +53,7 @@ class _DataProxyConnection(Connection):
 
     def __init__(self, client):
         super().__init__(client)
-        self._EXTRA_HEADERS["X-KAGGLE-PROXY-DATA"] = os.getenv(
+        self.extra_headers["X-KAGGLE-PROXY-DATA"] = os.getenv(
             "KAGGLE_DATA_PROXY_TOKEN")
 
     def api_request(self, *args, **kwargs):

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -23,6 +23,7 @@ class TestBigQuery(unittest.TestCase):
 
             def do_GET(self):
                 HTTPHandler.called = True
+                print(f"headers: {self.headers}")
                 HTTPHandler.header_found = any(
                     k for k in self.headers if k == "X-KAGGLE-PROXY-DATA" and self.headers[k] == "test-key")
                 self.send_response(200)

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -23,7 +23,6 @@ class TestBigQuery(unittest.TestCase):
 
             def do_GET(self):
                 HTTPHandler.called = True
-                print(f"headers: {self.headers}")
                 HTTPHandler.header_found = any(
                     k for k in self.headers if k == "X-KAGGLE-PROXY-DATA" and self.headers[k] == "test-key")
                 self.send_response(200)


### PR DESCRIPTION
…uery python library (https://github.com/googleapis/google-cloud-python/pull/7849/files#diff-340196d499e9d0eea25cd457f53bfa42L61).