### PR TITLE
Add support for GOOGLE_CLOUD_PROJECT env var, so users can set that o…

### DIFF
--- a/patches/sitecustomize.py
+++ b/patches/sitecustomize.py
@@ -5,7 +5,7 @@ kernel_integrations_var = os.getenv("KAGGLE_KERNEL_INTEGRATIONS")
 
 bq_user_jwt = os.getenv("KAGGLE_USER_SECRETS_TOKEN")
 if kaggle_proxy_token or bq_user_jwt:
-    from google.auth import credentials
+    from google.auth import credentials, environment_vars
     from google.cloud import bigquery
     from google.cloud.bigquery._http import Connection
     # TODO: Update this to the correct kaggle.gcp path once we no longer inject modules
@@ -13,10 +13,17 @@ if kaggle_proxy_token or bq_user_jwt:
     from kaggle_gcp import PublicBigqueryClient, KaggleKernelCredentials
 
     def monkeypatch_bq(bq_client, *args, **kwargs):
-        specified_project = kwargs.get('project')
         specified_credentials = kwargs.get('credentials')
         has_bigquery = get_integrations().has_bigquery()
-        if specified_project is None and specified_credentials is None and not has_bigquery:
+        # Prioritize passed in project id, but if it is missing look for env var. 
+        arg_project = kwargs.get('project')
+        explicit_project_id = arg_project or os.environ.get(environment_vars.PROJECT)
+        # This is a hack to get around the bug in google-cloud library.
+        # Remove these two lines once this is resolved:
+        # https://github.com/googleapis/google-cloud-python/issues/8108
+        if explicit_project_id:
+            kwargs['project'] = explicit_project_id
+        if explicit_project_id is None and specified_credentials is None and not has_bigquery:
             print("Using Kaggle's public dataset BigQuery integration.")
             return PublicBigqueryClient(*args, **kwargs)
 
@@ -26,6 +33,10 @@ if kaggle_proxy_token or bq_user_jwt:
                 if (not has_bigquery):
                     print('Please ensure you have selected a BigQuery '
                           'account in the Kernels Settings sidebar.')
+            print(kwargs)
+            print(os.environ.get(
+        environment_vars.PROJECT,
+        os.environ.get(environment_vars.LEGACY_PROJECT)))
             return bq_client(*args, **kwargs)
 
     # Monkey patches BigQuery client creation to use proxy or user-connected GCP account.

--- a/patches/sitecustomize.py
+++ b/patches/sitecustomize.py
@@ -33,10 +33,6 @@ if kaggle_proxy_token or bq_user_jwt:
                 if (not has_bigquery):
                     print('Please ensure you have selected a BigQuery '
                           'account in the Kernels Settings sidebar.')
-            print(kwargs)
-            print(os.environ.get(
-        environment_vars.PROJECT,
-        os.environ.get(environment_vars.LEGACY_PROJECT)))
             return bq_client(*args, **kwargs)
 
     # Monkey patches BigQuery client creation to use proxy or user-connected GCP account.

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -66,7 +66,7 @@ class TestBigQuery(unittest.TestCase):
         env.unset('KAGGLE_USER_SECRETS_TOKEN')
         with env:
             client = bigquery.Client(
-                default_query_job_config=bigquery.QueryJobConfig(maximum_bytes_billed=1e9))
+                default_query_job_config=bigquery.QueryJobConfig(maximum_bytes_billed=int(1e9)))
             self._test_proxy(client, should_use_proxy=True)
 
     def test_project_with_connected_account(self):
@@ -101,6 +101,15 @@ class TestBigQuery(unittest.TestCase):
         env.set('KAGGLE_KERNEL_INTEGRATIONS', 'BIGQUERY')
         with env:
             client = bigquery.Client(project='ANOTHER_PROJECT')
+            self._test_proxy(client, should_use_proxy=False)
+
+    def test_project_with_env_var_project_default_credentials(self):
+        env = EnvironmentVarGuard()
+        env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
+        env.set('KAGGLE_KERNEL_INTEGRATIONS', 'BIGQUERY')
+        env.set('GOOGLE_CLOUD_PROJECT', 'ANOTHER_PROJECT')
+        with env:
+            client = bigquery.Client()
             self._test_proxy(client, should_use_proxy=False)
 
     def test_simultaneous_clients(self):


### PR DESCRIPTION
…nce and not need to update each bigquery.client() call.

I found a bug in the core google-cloud python library with how they handle that env var. Basically, it fails if you provide that but not environment credentials, which is what we want users to do since we provide the credentials as a client constructor parameter (not in the environment). Because of this, I added a hack to get around the bug by explicitly passing that project env var value as the project parameter if it exists and no explicit project is passed. https://github.com/googleapis/google-cloud-python/issues/8108