### PR TITLE
Remove inaccessible NLTK corpus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN apt-get install -y libfreetype6-dev && \
     pros_cons ptb punkt qc reuters rslp rte sample_grammars semcor senseval sentence_polarity \
     sentiwordnet shakespeare sinica_treebank smultron snowball_data spanish_grammars \
     state_union stopwords subjectivity swadesh switchboard tagsets timit toolbox treebank \
-    twitter_samples udhr2 udhr unicode_samples universal_tagset universal_treebanks_v20 \
+    twitter_samples udhr2 udhr unicode_samples universal_tagset \
     vader_lexicon verbnet webtext word2vec_sample wordnet wordnet_ic words ycoe && \
     # Stop-words
     pip install stop-words && \


### PR DESCRIPTION
`universal_treebanks_v20` is failing to download.

Failure:
```
May 27 21:05:51 [nltk_data] Error downloading 'universal_treebanks_v20' from
May 27 21:05:51 [nltk_data]     <https://raw.githubusercontent.com/nltk/nltk_data/gh-
May 27 21:05:51 [nltk_data]     pages/packages/corpora/universal_treebanks_v20.zip>:
May 27 21:05:51 [nltk_data]     HTTP Error 503: first byte timeout
```

See for more context:
https://github.com/Kaggle/docker-python/blob/master/Dockerfile#L96

BUG=133762095