### PR TITLE
Retry nltk.downloader on error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,7 +95,8 @@ RUN apt-get install -y libfreetype6-dev && \
     mkdir -p /usr/share/nltk_data && \
     # NLTK Downloader no longer continues smoothly after an error, so we explicitly list
     # the corpuses that work
-    python -m nltk.downloader -d /usr/share/nltk_data abc alpino averaged_perceptron_tagger \
+    # "yes | ..." answers yes to the retry prompt in case of an error. See b/133762095.
+    yes | python -m nltk.downloader -d /usr/share/nltk_data abc alpino averaged_perceptron_tagger \
     basque_grammars biocreative_ppi bllip_wsj_no_aux \
     book_grammars brown brown_tei cess_cat cess_esp chat80 city_database cmudict \
     comtrans conll2000 conll2002 conll2007 crubadan dependency_treebank \


### PR DESCRIPTION
The downloader prompts for retry on failure
```
May 27 21:05:51 Error installing package. Retry? [n/y/e]
May 27 21:05:51 [0m[91mTraceback (most recent call last):
May 27 21:05:51   File "/opt/conda/lib/python3.6/runpy.py", line 193, in _run_module_as_main
May 27 21:05:51     "__main__", mod_spec)
May 27 21:05:51   File "/opt/conda/lib/python3.6/runpy.py", line 85, in _run_code
May 27 21:05:51     exec(code, run_globals)
May 27 21:05:51   File "/opt/conda/lib/python3.6/site-packages/nltk/downloader.py", line 2583, in <module>
May 27 21:05:51     halt_on_error=options.halt_on_error,
May 27 21:05:51   File "/opt/conda/lib/python3.6/site-packages/nltk/downloader.py", line 798, in download
May 27 21:05:51     choice = input().strip()
May 27 21:05:51 EOFError: EOF when reading a line
```

This change sends yes to this prompt.