### PR TITLE
Force uninstall of numpy to avoid error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,6 +135,8 @@ RUN apt-get -y install zlib1g-dev liblcms2-dev libwebp-dev libgeos-dev && \
     pip install cartopy && \
     # MXNet
     pip install mxnet && \
+    # Uninstall any old numpy
+    pip uninstall numpy; \
     pip install --upgrade numpy && \
     pip install gluonnlp && \
     pip install gluoncv && \


### PR DESCRIPTION
`ImportError: Something is wrong with the numpy installation. While importing we detected an older version of numpy in ['/opt/conda/lib/python3.6/site-packages/numpy']. One method of fixing this is to repeatedly uninstall numpy until none is found, then reinstall this version.`