### PR TITLE
Prevent llvmlite downgrade by pinning numba package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,9 @@ RUN pip install scipy && \
     pip install orderedmultidict && \
     pip install smhasher && \
     conda install -y -c bokeh bokeh && \
-    pip install datashader && \
+    # b/134599839 remove once datashader > 0.7.0 is released. We need an unreleased change ]
+    # removing the pinning on testpath.
+    pip install git+git://github.com/pyviz/datashader.git@e2a17725343f0ede20e5df4e2d1d72d33d00d1ff && \
     # Boruta (python implementation)
     cd /usr/local/src && git clone https://github.com/danielhomola/boruta_py.git && \
     cd boruta_py && python setup.py install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,10 @@ RUN pip install scipy && \
     pip install orderedmultidict && \
     pip install smhasher && \
     conda install -y -c bokeh bokeh && \
-    # b/134599839 remove once datashader > 0.7.0 is released. We need an unreleased change ]
+    # b/134599839: latest version requires llvmlite >= 0.39.0. Base image comes with 0.38.0.
+    # It fails to reinstall it because it is a distutil package. Remove pin once base image include newer verson of llvmlite.
+    pip install numba==0.38.0 && \
+    # b/134599839: remove once datashader > 0.7.0 is released. We need an unreleased change
     # removing the pinning on testpath.
     pip install git+git://github.com/pyviz/datashader.git@e2a17725343f0ede20e5df4e2d1d72d33d00d1ff && \
     # Boruta (python implementation)

--- a/Dockerfile
+++ b/Dockerfile
@@ -185,9 +185,7 @@ RUN pip install scipy && \
     # b/134599839: latest version requires llvmlite >= 0.39.0. Base image comes with 0.38.0.
     # It fails to reinstall it because it is a distutil package. Remove pin once base image include newer verson of llvmlite.
     pip install numba==0.38.0 && \
-    # b/134599839: remove once datashader > 0.7.0 is released. We need an unreleased change
-    # removing the pinning on testpath.
-    pip install git+git://github.com/pyviz/datashader.git@e2a17725343f0ede20e5df4e2d1d72d33d00d1ff && \
+    pip install datashader && \
     # Boruta (python implementation)
     cd /usr/local/src && git clone https://github.com/danielhomola/boruta_py.git && \
     cd boruta_py && python setup.py install && \


### PR DESCRIPTION
The build succeeds: https://ci.kaggle.net/job/kernels/job/docker-python/job/fix-datashader/4/

However, the tests are failing for a different reason (pthread_cancel and libgcc), I will fix it in a different PR.

BUG=134599839