### PR TITLE
Include the log.py file into the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -533,6 +533,7 @@ RUN pip install --upgrade dask && \
 ENV PYTHONUSERBASE "/root/.local"
 ADD patches/kaggle_gcp.py /root/.local/lib/python3.6/site-packages/kaggle_gcp.py
 ADD patches/kaggle_secrets.py /root/.local/lib/python3.6/site-packages/kaggle_secrets.py
+ADD patches/log.py /root/.local/lib/python3.6/site-packages/log.py
 ADD patches/sitecustomize.py /root/.local/lib/python3.6/site-packages/sitecustomize.py
 
 # TensorBoard Jupyter extension. Should be replaced with TensorBoard's provided magic once we have


### PR DESCRIPTION
Fixes failure introduced by #554.

The image fails to load and run tests because of the missing `log` module in sitecustomize.py

cc/ @vimota @erdalsivri 
