### PR TITLE
Remove version pin for pytorch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -189,7 +189,7 @@ RUN pip install scipy && \
     # PyTorch
     export CXXFLAGS="-std=c++11" && \
     export CFLAGS="-std=c99" && \
-    conda install -y pytorch-cpu=1.0.1 torchvision-cpu=0.2.2 -c pytorch && \
+    conda install -y pytorch-cpu torchvision-cpu -c pytorch && \
     # PyTorch Audio
     apt-get install -y sox libsox-dev libsox-fmt-all && \
     pip install cffi && \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -51,7 +51,7 @@ RUN pip uninstall -y tensorflow && \
     pip install /tmp/tensorflow_gpu/tensorflow*.whl && \
     rm -rf /tmp/tensorflow_gpu && \
     conda uninstall -y pytorch-cpu torchvision-cpu && \
-    conda install -y pytorch=1.0.1 torchvision=0.2.2 cudatoolkit=10.0 -c pytorch && \
+    conda install -y pytorch torchvision cudatoolkit=10.0 -c pytorch && \
     pip uninstall -y mxnet && \
     # b/126259508 --no-deps prevents numpy from being downgraded.
     pip install --no-deps mxnet-cu100 && \


### PR DESCRIPTION
The latest version of pytorch doesn't have incompatibilities with our other packages.