### PR TITLE
Remove python-dateutil pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -398,7 +398,6 @@ RUN pip install bcolz && \
     pip install ptyprocess && \
     pip install Pygments && \
     pip install pyparsing && \
-    pip install python-dateutil==2.6.0 && \
     pip install pytz && \
     pip install PyYAML && \
     pip install pyzmq && \


### PR DESCRIPTION
Removing unnecessary version pin (causes a downgrade and the latest version is fine).

This package is already installed near the top of the Dockerfile:
https://github.com/Kaggle/docker-python/blob/master/Dockerfile#L24