### PR TITLE
Downgrade tornado to the last known good version to fix notebook issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -406,7 +406,9 @@ RUN pip install bcolz && \
     pip install six && \
     pip install terminado && \
     pip install testpath && \
-    pip install tornado && \
+    # Latest version (6.0) of tornado breaks Jupyter notebook:
+    # https://github.com/jupyter/notebook/issues/4439
+    pip install tornado==5.0.2 && \
     pip install tqdm && \
     pip install traitlets && \
     pip install wcwidth && \


### PR DESCRIPTION
The latest version of tornado has a bug that breaks Jupyter notebook: https://github.com/jupyter/notebook/issues/4439