### PR TITLE
Use cuDNN 7.5.0 

### DIFF
--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -36,8 +36,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       cuda-nvml-dev-$CUDA_PKG_VERSION \
       cuda-minimal-build-$CUDA_PKG_VERSION \
       cuda-command-line-tools-$CUDA_PKG_VERSION \
-      libcudnn7=7.4.2.24-1+cuda10.0 \
-      libcudnn7-dev=7.4.2.24-1+cuda10.0 \
+      libcudnn7=7.5.0.56-1+cuda10.0 \
+      libcudnn7-dev=7.5.0.56-1+cuda10.0 \
       libnccl2=2.4.2-1+cuda10.0 \
       libnccl-dev=2.4.2-1+cuda10.0 && \
     ln -s /usr/local/cuda-10.0 /usr/local/cuda && \

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 
 from keras.models import Sequential
-from keras.layers import Dense, Dropout, Flatten, Conv2D, MaxPooling2D
+from keras.layers import Dense, Dropout, Flatten, Conv2D, MaxPooling2D, CuDNNLSTM
 from keras.optimizers import RMSprop, SGD
 from keras.utils.np_utils import to_categorical
 
@@ -58,3 +58,22 @@ class TestKeras(unittest.TestCase):
         model.compile(loss='categorical_crossentropy', optimizer=sgd)
         model.fit(x_train, y_train, batch_size=32, epochs=1)
         model.evaluate(x_test, y_test, batch_size=32)
+
+    def test_cudnn_lstm(self):
+        x_train = np.random.random((100, 100, 100))
+        y_train = keras.utils.to_categorical(np.random.randint(10, size=(100, 1)), num_classes=10)
+        x_test = np.random.random((20, 100, 100))
+        y_test = keras.utils.to_categorical(np.random.randint(10, size=(20, 1)), num_classes=10)
+
+        sgd = SGD(lr=0.01, decay=1e-6, momentum=0.9, nesterov=True)
+
+        model = Sequential()
+        model.add(CuDNNLSTM(32, return_sequences=True, input_shape=(100, 100)))
+        model.add(Flatten())
+        model.add(Dense(10, activation='softmax'))
+
+
+        model.compile(loss='categorical_crossentropy', optimizer=sgd)
+        model.fit(x_train, y_train, batch_size=32, epochs=1)
+        model.evaluate(x_test, y_test, batch_size=32)
+

--- a/tests/test_keras.py
+++ b/tests/test_keras.py
@@ -9,6 +9,8 @@ from keras.layers import Dense, Dropout, Flatten, Conv2D, MaxPooling2D, CuDNNLST
 from keras.optimizers import RMSprop, SGD
 from keras.utils.np_utils import to_categorical
 
+from common import gpu_test
+
 class TestKeras(unittest.TestCase):
     def test_train(self):
         train = pd.read_csv("/input/tests/data/train.csv")
@@ -59,6 +61,7 @@ class TestKeras(unittest.TestCase):
         model.fit(x_train, y_train, batch_size=32, epochs=1)
         model.evaluate(x_test, y_test, batch_size=32)
 
+    @gpu_test
     def test_cudnn_lstm(self):
         x_train = np.random.random((100, 100, 100))
         y_train = keras.utils.to_categorical(np.random.randint(10, size=(100, 1)), num_classes=10)

--- a/tests/test_tensorflow.py
+++ b/tests/test_tensorflow.py
@@ -64,3 +64,11 @@ class TestTensorflow(unittest.TestCase):
                 result = sess.run(op)
 
                 self.assertEqual(np.array(18, dtype=np.float32, ndmin=2), result)
+
+    @gpu_test
+    def test_is_built_with_cuda(self):
+        self.assertTrue(tf.test.is_built_with_cuda())
+
+    @gpu_test
+    def test_is_gpu_available(self):
+        self.assertTrue(tf.test.is_gpu_available(cuda_only=True))


### PR DESCRIPTION
- Use cuDNN 7.5.0, this is the version the tensorflow wheels are built with: https://github.com/Kaggle/docker-python/blob/master/tensorflow-whl/Dockerfile#L41
- Added more tests to prevent regression.

The new `test_cudnn_lstm` fails with the last bad release:
```
Traceback (most recent call last):
  File "/input/tests/test_keras.py", line 59, in test_conv2d
    model.fit(x_train, y_train, batch_size=32, epochs=1)
  File "/opt/conda/lib/python3.6/site-packages/keras/engine/training.py", line 1039, in fit
    validation_steps=validation_steps)
  File "/opt/conda/lib/python3.6/site-packages/keras/engine/training_arrays.py", line 199, in fit_loop
    outs = f(ins_batch)
  File "/opt/conda/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py", line 2715, in __call__
    return self._call(inputs)
  File "/opt/conda/lib/python3.6/site-packages/keras/backend/tensorflow_backend.py", line 2675, in _call
    fetched = self._callable_fn(*array_vals)
  File "/opt/conda/lib/python3.6/site-packages/tensorflow/python/client/session.py", line 1439, in __call__
    run_metadata_ptr)
  File "/opt/conda/lib/python3.6/site-packages/tensorflow/python/framework/errors_impl.py", line 528, in __exit__
    c_api.TF_GetCode(self.status.status))
tensorflow.python.framework.errors_impl.UnknownError: Failed to get convolution algorithm. This is probably because cuDNN failed to initialize, so try looking to see if a warning log message was printed above.
	 [[{{node conv2d_1/convolution}}]]
	 [[{{node loss/mul}}]]

```

And succeeds with the new image.
