### PR TITLE
Fixes dataproxy connection object not returning api response. Makes b…

### DIFF
--- a/patches/kaggle_gcp.py
+++ b/patches/kaggle_gcp.py
@@ -69,7 +69,7 @@ class _DataProxyConnection(Connection):
         """Wrap Connection.api_request in order to handle errors gracefully.
         """
         try:
-            super().api_request(*args, **kwargs)
+            return super().api_request(*args, **kwargs)
         except Forbidden as e:
             msg = ("Permission denied using Kaggle's public BigQuery integration. "
                    "Did you mean to select a BigQuery account in the Kernels Settings sidebar?")

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -1,5 +1,7 @@
 import unittest
 import os
+import json
+from unittest.mock import patch
 import threading
 from test.support import EnvironmentVarGuard
 from urllib.parse import urlparse
@@ -8,44 +10,64 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 from google.cloud import bigquery
 from google.auth.exceptions import DefaultCredentialsError
+from google.cloud.bigquery._http import Connection
 from kaggle_gcp import KaggleKernelCredentials, PublicBigqueryClient
+import kaggle_secrets
 
 
 class TestBigQuery(unittest.TestCase):
 
+    API_BASE_URL = "http://127.0.0.1:2121"
     def _test_proxy(self, client, should_use_proxy):
         class HTTPHandler(BaseHTTPRequestHandler):
             called = False
-            header_found = False
+            bearer_header_found = False
+            proxy_header_found = False
 
             def do_HEAD(self):
                 self.send_response(200)
 
             def do_GET(self):
                 HTTPHandler.called = True
-                HTTPHandler.header_found = any(
+                HTTPHandler.proxy_header_found = any(
                     k for k in self.headers if k == "X-KAGGLE-PROXY-DATA" and self.headers[k] == "test-key")
+                HTTPHandler.bearer_header_found = any(
+                    k for k in self.headers if k == "authorization" and self.headers[k] == "Bearer secret")
                 self.send_response(200)
+                self.send_header("Content-type", "application/json")
+                self.end_headers()
+                sample_dataset = {
+                    "id": "bigqueryproject:datasetname",
+                    "datasetReference": {
+                        "datasetId": "datasetname",
+                        "projectId": "bigqueryproject"
+                    }
+                }
+                self.wfile.write(json.dumps({"kind": "bigquery#datasetList", "datasets": [sample_dataset]}).encode("utf-8"))
 
-        server_address = urlparse(os.getenv('KAGGLE_DATA_PROXY_URL'))
+        server_address = urlparse(os.getenv('KAGGLE_DATA_PROXY_URL') if should_use_proxy else self.API_BASE_URL)
         with HTTPServer((server_address.hostname, server_address.port), HTTPHandler) as httpd:
             threading.Thread(target=httpd.serve_forever).start()
 
-            try:
-                for _ in client.list_datasets():
-                    pass
-            except:
-                pass
-
+            for dataset in client.list_datasets():
+                self.assertEquals(dataset.dataset_id, "datasetname")    
+            
             httpd.shutdown()
+            self.assertTrue(
+                    HTTPHandler.called, msg="Fake server was not called from the BQ client, but should have been.")
             if should_use_proxy:
+                self.assertFalse(
+                    HTTPHandler.bearer_header_found, msg="authorization header was included in the BQ proxy request.")
                 self.assertTrue(
-                    HTTPHandler.called, msg="Fake server did not receive a request from the BQ client.")
-                self.assertTrue(
-                    HTTPHandler.header_found, msg="X-KAGGLE-PROXY-DATA header was missing from the BQ request.")
+                    HTTPHandler.proxy_header_found, msg="X-KAGGLE-PROXY-DATA header was missing from the BQ proxy request.")
             else:
                 self.assertFalse(
-                    HTTPHandler.called, msg="Fake server was called from the BQ client, but should not have been.")
+                    HTTPHandler.proxy_header_found, msg="X-KAGGLE-PROXY-DATA header was included in the BQ request.")
+                self.assertTrue(
+                    HTTPHandler.bearer_header_found, msg="authorization header was missing from the BQ request.")
+    
+    def _setup_mocks(self, api_url_mock):
+        api_url_mock.__str__.return_value = self.API_BASE_URL
 
     def test_proxy_using_library(self):
         env = EnvironmentVarGuard()
@@ -69,7 +91,10 @@ class TestBigQuery(unittest.TestCase):
                 default_query_job_config=bigquery.QueryJobConfig(maximum_bytes_billed=int(1e9)))
             self._test_proxy(client, should_use_proxy=True)
 
-    def test_project_with_connected_account(self):
+    @patch.object(Connection, 'API_BASE_URL')
+    @patch.object(kaggle_secrets.UserSecretsClient, 'get_bigquery_access_token', return_value=('secret',1000))
+    def test_project_with_connected_account(self, mock_access_token, ApiUrlMock):
+        self._setup_mocks(ApiUrlMock)
         env = EnvironmentVarGuard()
         env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
         with env:
@@ -77,7 +102,10 @@ class TestBigQuery(unittest.TestCase):
                 project='ANOTHER_PROJECT', credentials=KaggleKernelCredentials())
             self._test_proxy(client, should_use_proxy=False)
 
-    def test_project_with_empty_integrations(self):
+    @patch.object(Connection, 'API_BASE_URL')
+    @patch.object(kaggle_secrets.UserSecretsClient, 'get_bigquery_access_token', return_value=('secret',1000))
+    def test_project_with_empty_integrations(self, mock_access_token, ApiUrlMock):
+        self._setup_mocks(ApiUrlMock)
         env = EnvironmentVarGuard()
         env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
         env.set('KAGGLE_KERNEL_INTEGRATIONS', '')
@@ -86,7 +114,10 @@ class TestBigQuery(unittest.TestCase):
                 project='ANOTHER_PROJECT', credentials=KaggleKernelCredentials())
             self._test_proxy(client, should_use_proxy=False)
 
-    def test_project_with_connected_account_unrelated_integrations(self):
+    @patch.object(Connection, 'API_BASE_URL')
+    @patch.object(kaggle_secrets.UserSecretsClient, 'get_bigquery_access_token', return_value=('secret',1000))
+    def test_project_with_connected_account_unrelated_integrations(self, mock_access_token, ApiUrlMock):
+        self._setup_mocks(ApiUrlMock)
         env = EnvironmentVarGuard()
         env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
         env.set('KAGGLE_KERNEL_INTEGRATIONS', 'GCS:ANOTHER_ONE')
@@ -95,7 +126,10 @@ class TestBigQuery(unittest.TestCase):
                 project='ANOTHER_PROJECT', credentials=KaggleKernelCredentials())
             self._test_proxy(client, should_use_proxy=False)
 
-    def test_project_with_connected_account_default_credentials(self):
+    @patch.object(Connection, 'API_BASE_URL')
+    @patch.object(kaggle_secrets.UserSecretsClient, 'get_bigquery_access_token', return_value=('secret',1000))
+    def test_project_with_connected_account_default_credentials(self, mock_access_token, ApiUrlMock):
+        self._setup_mocks(ApiUrlMock)
         env = EnvironmentVarGuard()
         env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
         env.set('KAGGLE_KERNEL_INTEGRATIONS', 'BIGQUERY')
@@ -103,7 +137,10 @@ class TestBigQuery(unittest.TestCase):
             client = bigquery.Client(project='ANOTHER_PROJECT')
             self._test_proxy(client, should_use_proxy=False)
 
-    def test_project_with_env_var_project_default_credentials(self):
+    @patch.object(Connection, 'API_BASE_URL')
+    @patch.object(kaggle_secrets.UserSecretsClient, 'get_bigquery_access_token', return_value=('secret',1000))
+    def test_project_with_env_var_project_default_credentials(self, mock_access_token, ApiUrlMock):
+        self._setup_mocks(ApiUrlMock)
         env = EnvironmentVarGuard()
         env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
         env.set('KAGGLE_KERNEL_INTEGRATIONS', 'BIGQUERY')
@@ -112,7 +149,10 @@ class TestBigQuery(unittest.TestCase):
             client = bigquery.Client()
             self._test_proxy(client, should_use_proxy=False)
 
-    def test_simultaneous_clients(self):
+    @patch.object(Connection, 'API_BASE_URL')
+    @patch.object(kaggle_secrets.UserSecretsClient, 'get_bigquery_access_token', return_value=('secret',1000))
+    def test_simultaneous_clients(self, mock_access_token, ApiUrlMock):
+        self._setup_mocks(ApiUrlMock)
         env = EnvironmentVarGuard()
         env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
         with env:

--- a/tests/test_bigquery_proxy.py
+++ b/tests/test_bigquery_proxy.py
@@ -1,0 +1,77 @@
+import unittest
+import os
+import json
+from unittest.mock import patch
+import threading
+from test.support import EnvironmentVarGuard
+from urllib.parse import urlparse
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from google.cloud import bigquery
+from google.auth.exceptions import DefaultCredentialsError
+from google.cloud.bigquery._http import Connection
+from kaggle_gcp import KaggleKernelCredentials, PublicBigqueryClient
+import kaggle_secrets
+
+
+class TestBigQuery(unittest.TestCase):
+
+    def _test_proxy(self, client):
+        class HTTPHandler(BaseHTTPRequestHandler):
+            called = False
+            proxy_header_found = False
+
+            def do_HEAD(self):
+                self.send_response(200)
+
+            def do_GET(self):
+                HTTPHandler.called = True
+                HTTPHandler.proxy_header_found = any(
+                    k for k in self.headers if k == "X-KAGGLE-PROXY-DATA" and self.headers[k] == "test-key")
+                self.send_response(200)
+                self.send_header("Content-type", "application/json")
+                self.end_headers()
+                sample_dataset = {
+                    "id": "bigqueryproject:datasetname",
+                    "datasetReference": {
+                        "datasetId": "datasetname",
+                        "projectId": "bigqueryproject"
+                    }
+                }
+                self.wfile.write(json.dumps({"kind": "bigquery#datasetList", "datasets": [sample_dataset]}).encode("utf-8"))
+
+        server_address = urlparse(os.getenv('KAGGLE_DATA_PROXY_URL'))
+        with HTTPServer((server_address.hostname, server_address.port), HTTPHandler) as httpd:
+            threading.Thread(target=httpd.serve_forever).start()
+
+            for dataset in client.list_datasets():
+                self.assertEqual(dataset.dataset_id, "datasetname")    
+            
+            httpd.shutdown()
+            self.assertTrue(
+                    HTTPHandler.called, msg="Fake server was not called from the BQ client, but should have been.")
+            self.assertTrue(
+                HTTPHandler.proxy_header_found, msg="X-KAGGLE-PROXY-DATA header was missing from the BQ proxy request.")
+
+    def test_proxy_using_library(self):
+        env = EnvironmentVarGuard()
+        env.unset('KAGGLE_USER_SECRETS_TOKEN')
+        with env:
+            client = PublicBigqueryClient()
+            self._test_proxy(client)
+
+    def test_proxy_no_project(self):
+        env = EnvironmentVarGuard()
+        env.unset('KAGGLE_USER_SECRETS_TOKEN')
+        with env:
+            client = bigquery.Client()
+            self._test_proxy(client)
+
+    def test_proxy_with_kwargs(self):
+        env = EnvironmentVarGuard()
+        env.unset('KAGGLE_USER_SECRETS_TOKEN')
+        with env:
+            client = bigquery.Client(
+                default_query_job_config=bigquery.QueryJobConfig(maximum_bytes_billed=int(1e9)))
+            self._test_proxy(client)


### PR DESCRIPTION
…igquery unit test more robust:  tests api call end to end with data, doesn't swallow errors.