### PR TITLE
Add LABELs and files in /etc/ to identify build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,15 @@ ARG BASE_TAG=2019.03
 FROM gcr.io/kaggle-images/python-tensorflow-whl:1.14.0-py36 as tensorflow_whl
 FROM continuumio/anaconda3:${BASE_TAG}
 
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+LABEL git-commit=$GIT_COMMIT
+LABEL build-date=$BUILD_DATE
+
+# Correlate current release with the git hash inside the kernel editor by running `!cat /etc/git_commit`.
+RUN echo "$GIT_COMMIT" > /etc/git_commit && echo "$BUILD_DATE" > /etc/build_date
+
 ADD clean-layer.sh  /tmp/clean-layer.sh
 ADD patches/nbconvert-extensions.tpl /opt/kaggle/nbconvert-extensions.tpl
 

--- a/build
+++ b/build
@@ -52,6 +52,9 @@ while :; do
     shift
 done
 
+BUILD_ARGS+=" --build-arg GIT_COMMIT=$(git rev-parse HEAD)"
+BUILD_ARGS+=" --build-arg BUILD_DATE=$(date '+%Y%m%d-%H%M%S')"
+
 readonly CACHE_FLAG
 readonly DOCKERFILE
 readonly IMAGE_TAG


### PR DESCRIPTION
Fixes #532 

Added the git commit hash and the build date to:
- Docker image LABELs
- Files under /etc (to easily run cat /etc/git_commit inside the kernel editor)

This allow to correlate easily an image with a specific git commit hash and build date.