### PR TITLE
Install category_encoders from GitHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -346,7 +346,8 @@ RUN pip install --upgrade cython && \
     pip install fasttext && \
     apt-get install -y libhunspell-dev && pip install hunspell && \
     pip install annoy && \
-    pip install category_encoders && \
+    # Need to use CountEncoder from category_encoders before it's officially released
+    pip install git+https://github.com/scikit-learn-contrib/categorical-encoding.git && \
     # Newer version crashes (latest = 1.14.0) when running tensorflow.
     # python -c "from google.cloud import bigquery; import tensorflow". This flow is common because bigquery is imported in kaggle_gcp.py
     # which is loaded at startup.

--- a/tests/test_category_encoders.py
+++ b/tests/test_category_encoders.py
@@ -1,0 +1,16 @@
+import unittest
+
+## Need to make sure we have CountEncoder available from the category_encoders library
+class TestCategoryEncoders(unittest.TestCase):
+    def test_count_encoder(self):
+
+        from category_encoders import CountEncoder
+        import pandas as pd
+
+        encoder = CountEncoder(cols="data")
+
+        data = pd.DataFrame([1, 2, 3, 1, 4, 5, 3, 1], columns=["data"])
+
+        encoded = encoder.fit_transform(data)
+        self.assertTrue((encoded.data == [3, 1, 2, 3, 1, 1, 2, 3]).all())
+


### PR DESCRIPTION
We want to use CountEncoder from category_encoders but it isn't
available from the version on PyPI. However, it has been merged into
the master branch on the GitHub repo. So, install from GitHub!

I've also included a test to make sure we can use CountEncoder.