### PR TITLE
Change monkeypatching for GCS

### DIFF
--- a/patches/kaggle_gcp.py
+++ b/patches/kaggle_gcp.py
@@ -178,13 +178,13 @@ def init_gcs():
     from kaggle_gcp import KaggleKernelCredentials
     gcs_client_init = storage.Client.__init__
     def monkeypatch_gcs(self, *args, **kwargs):
-        specified_credentials = kwargs.get('credentials')
-        if specified_credentials is None:
-            Log.info("No credentials specified, using KaggleKernelCredentials.")
-            kwargs['credentials'] = KaggleKernelCredentials(target=GcpTarget.GCS)
-        return gcs_client_init(self, *args, **kwargs)
+        specified_credentials = kwargs.get('credentials')
+        if specified_credentials is None:
+            Log.info("No credentials specified, using KaggleKernelCredentials.")
+            kwargs['credentials'] = KaggleKernelCredentials(target=GcpTarget.GCS)
+        return gcs_client_init(self, *args, **kwargs)
 
-    storage.Client.__init__ = monkeypatch_gcs
+    storage.Client.__init__ = monkeypatch_gcs
     return storage
 
 def init():

--- a/patches/kaggle_gcp.py
+++ b/patches/kaggle_gcp.py
@@ -177,7 +177,7 @@ def init_gcs():
     from kaggle_secrets import GcpTarget
     from kaggle_gcp import KaggleKernelCredentials
     gcs_client_init = storage.Client.__init__
-    def monkeypatch_gcs(self, *args, **kwargs):
+    def monkeypatch_gcs(self, *args, **kwargs):
         specified_credentials = kwargs.get('credentials')
         if specified_credentials is None:
             Log.info("No credentials specified, using KaggleKernelCredentials.")

--- a/patches/sitecustomize.py
+++ b/patches/sitecustomize.py
@@ -68,15 +68,16 @@ def init_gcs():
    from kaggle_secrets import GcpTarget
    from kaggle_gcp import KaggleKernelCredentials
    from google.cloud import storage
-   def monkeypatch_gcs(gcs_client, *args, **kwargs):
+
+   gcs_client_init = storage.Client.__init__
+   def monkeypatch_gcs(self, *args, **kwargs):
        specified_credentials = kwargs.get('credentials')
        if specified_credentials is None:
            Log.info("No credentials specified, using KaggleKernelCredentials.")
            kwargs['credentials'] = KaggleKernelCredentials(target=GcpTarget.GCS)
-       return gcs_client(*args, **kwargs)
+       return gcs_client_init(self, *args, **kwargs)
 
-   gcs_client = storage.Client
-   storage.Client = lambda *args, **kwargs:  monkeypatch_gcs(gcs_client, *args, **kwargs)
+   storage.Client.__init__ = monkeypatch_gcs
 
 
 init()

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -29,7 +29,9 @@ class TestStorage(unittest.TestCase):
             self.assertIsNotNone(client._credentials)
 
     def test_annonymous_client(self):
-        # TODO: the following will not work with current monkey patching.
+        env = EnvironmentVarGuard()
+        env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
+        env.set('KAGGLE_KERNEL_INTEGRATIONS', 'GCS')
         anonymous = storage.Client.create_anonymous_client()
         self.assertIsNotNone(anonymous)
 

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -32,8 +32,7 @@ class TestStorage(unittest.TestCase):
         env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
         env.set('KAGGLE_KERNEL_INTEGRATIONS', 'GCS')
         with env:
-            from sitecustomize import init
-            init()
+            init_gcs()
             anonymous = storage.Client.create_anonymous_client()
             self.assertIsNotNone(anonymous)
 

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -32,8 +32,11 @@ class TestStorage(unittest.TestCase):
         env = EnvironmentVarGuard()
         env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
         env.set('KAGGLE_KERNEL_INTEGRATIONS', 'GCS')
-        anonymous = storage.Client.create_anonymous_client()
-        self.assertIsNotNone(anonymous)
+        with env:
+            from sitecustomize import init
+            init()
+            anonymous = storage.Client.create_anonymous_client()
+            self.assertIsNotNone(anonymous)
 
     def test_default_credentials_gcs_enabled(self):
         env = EnvironmentVarGuard()


### PR DESCRIPTION
Instead of monkeypatching by changing `storage.Client` to a lambda, we just mokeypatch the `storage.Client`s constructor.