### PR TITLE
Add message to user when they use private bigquery without project id…

### DIFF
--- a/patches/kaggle_gcp.py
+++ b/patches/kaggle_gcp.py
@@ -145,7 +145,6 @@ def init_bigquery():
             Log.info(msg)
             print(msg)
             return PublicBigqueryClient(*args, **kwargs)
-
         else:
             if specified_credentials is None:
                 Log.info("No credentials specified, using KaggleKernelCredentials.")
@@ -154,6 +153,10 @@ def init_bigquery():
                     Log.info("No bigquery integration found, creating client anyways.")
                     print('Please ensure you have selected a BigQuery '
                         'account in the Kernels Settings sidebar.')
+            if explicit_project_id is None:
+                Log.info("No project specified while using the unmodified client.")
+                print('Please ensure you specify a project id when creating the client'
+                    'in order to use your BigQuery account.')
             return bq_client(*args, **kwargs)
 
     # Monkey patches BigQuery client creation to use proxy or user-connected GCP account.

--- a/patches/kaggle_gcp.py
+++ b/patches/kaggle_gcp.py
@@ -1,4 +1,5 @@
 import os
+import inspect
 from google.auth import credentials
 from google.auth.exceptions import RefreshError
 from google.cloud import bigquery
@@ -111,6 +112,8 @@ class PublicBigqueryClient(bigquery.client.Client):
         # TODO: Remove this once https://github.com/googleapis/google-cloud-python/issues/7122 is implemented.
         self._connection = _DataProxyConnection(self)
 
+def has_been_monkeypatched(method):
+    return "kaggle_gcp" in inspect.getsourcefile(method)
 
 def init_bigquery():
     from google.auth import environment_vars
@@ -156,15 +159,16 @@ def init_bigquery():
             if explicit_project_id is None:
                 Log.info("No project specified while using the unmodified client.")
                 print('Please ensure you specify a project id when creating the client'
-                    'in order to use your BigQuery account.')
+                    ' in order to use your BigQuery account.')
             return bq_client(*args, **kwargs)
 
     # Monkey patches BigQuery client creation to use proxy or user-connected GCP account.
     # Deprecated in favor of Kaggle.DataProxyClient().
     # TODO: Remove this once uses have migrated to that new interface.
     bq_client = bigquery.Client
-    bigquery.Client = lambda *args, **kwargs:  monkeypatch_bq(
-        bq_client, *args, **kwargs)
+    if (not has_been_monkeypatched(bigquery.Client)):
+        bigquery.Client = lambda *args, **kwargs:  monkeypatch_bq(
+            bq_client, *args, **kwargs)
     return bigquery
 
 def init_gcs():
@@ -187,7 +191,8 @@ def init_gcs():
             kwargs['credentials'] = KaggleKernelCredentials(target=GcpTarget.GCS)
         return gcs_client_init(self, *args, **kwargs)
 
-    storage.Client.__init__ = monkeypatch_gcs
+    if (not has_been_monkeypatched(storage.Client.__init__)):
+        storage.Client.__init__ = monkeypatch_gcs
     return storage
 
 def init():

--- a/tests/test_bigquery_proxy.py
+++ b/tests/test_bigquery_proxy.py
@@ -11,7 +11,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from google.cloud import bigquery
 from google.auth.exceptions import DefaultCredentialsError
 from google.cloud.bigquery._http import Connection
-from kaggle_gcp import KaggleKernelCredentials, PublicBigqueryClient
+from kaggle_gcp import KaggleKernelCredentials, PublicBigqueryClient, init_bigquery
 import kaggle_secrets
 
 
@@ -67,6 +67,15 @@ class TestBigQuery(unittest.TestCase):
         with env:
             client = bigquery.Client()
             self._test_proxy(client)
+    
+    def test_monkeypatching_idempotent(self):
+        env = EnvironmentVarGuard()
+        env.unset('KAGGLE_USER_SECRETS_TOKEN')
+        with env:
+            client1 = bigquery.Client
+            init_bigquery()
+            client2 = bigquery.Client
+            self.assertEqual(client1, client2)
 
     def test_proxy_with_kwargs(self):
         env = EnvironmentVarGuard()

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -44,3 +44,13 @@ class TestStorage(unittest.TestCase):
             init_gcs()
             client = storage.Client(project="xyz")
             self.assertIsInstance(client._credentials, KaggleKernelCredentials)
+    
+    def test_monkeypatching_idempotent(self):
+        env = EnvironmentVarGuard()
+        env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
+        env.set('KAGGLE_KERNEL_INTEGRATIONS', 'GCS')
+        with env:
+            client1 = storage.Client.__init__
+            init_gcs()
+            client2 = storage.Client.__init__
+            self.assertEqual(client1, client2)


### PR DESCRIPTION
… which will cause a DefaultCredentialsError. Additionally, it ensures that we only monkeypatch the desired module methods once, to avoid double wrapping the methods.

b/138330551