### PR TITLE
Add bqplot and qgrid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -493,7 +493,7 @@ RUN pip install flashtext && \
     pip install albumentations && \
     pip install pytorch-ignite && \
     pip install qgrid && \
-    pip install bqplot &&
+    pip install bqplot && \
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -492,6 +492,8 @@ RUN pip install flashtext && \
     pip install plotly_express && \
     pip install albumentations && \
     pip install pytorch-ignite && \
+    pip install qgrid && \
+    pip install bqplot &&
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages

--- a/tests/qgrid.py
+++ b/tests/qgrid.py
@@ -1,0 +1,15 @@
+import unittest
+import pandas as pd
+from qgrid import QgridWidget
+
+class TestQgrid(unittest.TestCase):
+    def test_nans():
+        df = pd.DataFrame([(pd.Timestamp('2017-02-02'), np.nan),
+                           (4, 2),
+                           ('foo', 'bar')])
+        view = QgridWidget(df=df)
+        view._handle_qgrid_msg_helper({
+            'type': 'change_sort',
+            'sort_field': 1,
+            'sort_ascending': True
+        })

--- a/tests/test_bqplot.py
+++ b/tests/test_bqplot.py
@@ -1,0 +1,14 @@
+import unittest
+import numpy as np
+import bqplot.pyplot as plt
+
+class TestBqplot(unittest.TestCase):
+    def test_figure(self):
+        size = 100
+        scale = 100.0
+        np.random.seed(0)
+        x_data = np.arange(size)
+        y_data = np.cumsum(np.random.randn(size)  * scale)
+        fig = plt.figure(title='First Example')
+        plt.plot(y_data)
+        fig.save_png()


### PR DESCRIPTION
This PR adds `bqplot` (https://github.com/bloomberg/bqplot) and `qgrid` (https://github.com/quantopian/qgrid) to the Dockerfile. `bqplot` is an interactive plotting package with 2000+ GitHub stars. `qgrid` is a widget for interactive exploration of pandas dataframes and has 1800+GitHub stars. Both packages are very helpful for interactive exploratory data analysis.