### PR TITLE
Fix build failure while configuring Keras

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -148,17 +148,6 @@ RUN apt-get -y install zlib1g-dev liblcms2-dev libwebp-dev libgeos-dev && \
     wget --no-verbose --no-check-certificate -i latest -O h2o.zip && rm latest && \
     unzip h2o.zip && rm h2o.zip && cp h2o-*/h2o.jar . && \
     pip install `find . -name "*whl"` && \
-    # Keras setup
-    # Keras likes to add a config file in a custom directory when it's
-    # first imported. This doesn't work with our read-only filesystem, so we
-    # have it done now
-    python -c "from keras.models import Sequential"  && \
-    # Switch to TF backend
-    sed -i 's/theano/tensorflow/' /root/.keras/keras.json  && \
-    # Re-run it to flush any more disk writes
-    python -c "from keras.models import Sequential; from keras import backend; print(backend._BACKEND)" && \
-    # Keras reverts to /tmp from ~ when it detects a read-only file system
-    mkdir -p /tmp/.keras && cp /root/.keras/keras.json /tmp/.keras && \
     /tmp/clean-layer.sh
 
 # b/128333086: Set PROJ_LIB to points to the proj4 cartographic library.


### PR DESCRIPTION
A new version of Keras (2.2.5) was released on August 22nd 2019 and the build has been failing since then.

The previous green build was using Keras (2.2.4) released in October 2018.

The build error was:
Aug 29 17:01:30 AttributeError: module 'keras.backend' has no attribute '_BACKEND'

The latest version of Keras has tensorflow as its default backend. No need to configure.
I remove the default backend configuration logic which was causing the issue.

The build is now passing but an unrelated test failure caused by pytorch will also need to be addressed (in a different PR):
Aug 29 17:01:30 AttributeError: module 'keras.backend' has no attribute '_BACKEND'

BUG=140243312