### PR TITLE
Pin pytorch/audio to the last good commit to work around broken build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -189,9 +189,10 @@ RUN pip install scipy && \
     export CFLAGS="-std=c99" && \
     conda install -y pytorch-cpu torchvision-cpu -c pytorch && \
     # PyTorch Audio
+    # TODO: remove pinning to a git commit hash when issue https://github.com/pytorch/audio/issues/262 is resolved.
     apt-get install -y sox libsox-dev libsox-fmt-all && \
     pip install cffi && \
-    pip install git+git://github.com/pytorch/audio.git && \
+    pip install git+git://github.com/pytorch/audio.git@8528ac78cd0522c37216b18ef7ec1822d126d633 && \
     /tmp/clean-layer.sh
 
 # vtk with dependencies


### PR DESCRIPTION
The `pytorch/audio` build is currently broken: https://travis-ci.org/pytorch/audio/jobs/578519924

The issue has been [reported](https://github.com/pytorch/audio/issues/262). This change pins our build to the last good commit.

BUG=140432752