### PR TITLE
Add missing allennlp dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -435,6 +435,7 @@ RUN pip install jsonnet overrides tensorboardX && \
     pip install unidecode parsimonious>=0.8.0 sqlparse>=0.2.4 word2number>=1.1 && \
     pip install pytorch-pretrained-bert>=0.6.0 pytorch-transformers==1.1.0 jsonpickle && \
     pip install requests>=2.18 editdistance conllu==0.11 && \
+    pip install conllu==1.3.1 && \
     pip install --no-dependencies allennlp && \
     /tmp/clean-layer.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -433,7 +433,7 @@ RUN pip install bcolz && \
 RUN pip install jsonnet overrides tensorboardX && \
     pip install flask>=1.0.2 flask-cors>=3.0.7 gevent>=1.3.6 && \
     pip install unidecode parsimonious>=0.8.0 sqlparse>=0.2.4 word2number>=1.1 && \
-    pip install pytorch-pretrained-bert>=0.6.0 jsonpickle && \
+    pip install pytorch-pretrained-bert>=0.6.0 pytorch-transformers==1.1.0 jsonpickle && \
     pip install requests>=2.18 editdistance conllu==0.11 && \
     pip install --no-dependencies allennlp && \
     /tmp/clean-layer.sh


### PR DESCRIPTION
The allennlp package dependencies are installed manually because of a compatibility issue with unnecessary dependencies (e.g. awscli).

A new version of `allennlp` was released on August 21st 2019 which added a new dependency. This PR simply adds it to the our Dockerfile:
https://github.com/allenai/allennlp/blob/27ebcf6ba3e02afe341a5e62cb1a7d5c6906c0c9/requirements.txt#L64

BUG=140440350
