### PR TITLE
Keep numpy 1.16.4 to prevent deprecation warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,7 +137,8 @@ RUN apt-get -y install zlib1g-dev liblcms2-dev libwebp-dev libgeos-dev && \
     pip install cartopy && \
     # MXNet
     pip install mxnet && \
-    pip install --upgrade numpy && \
+    # b/140423854 v1.17 prints annoying deprecation warning messages with TensorFlow 1.14.0. Remove once we upgrade to TF 1.14.1 or 2.x
+    pip install numpy==1.16.4 && \
     pip install gluonnlp && \
     pip install gluoncv && \
     # h2o (requires java)


### PR DESCRIPTION
numpy 1.17 (latest) is causing annoying deprecation warnings to be printed in users notebook when they use TensorFlow. TensorFlow has a fixed which will be included in the 1.14.1 version (not yet released).

For now, let's pin numpy. We can remove the pin once TensorFlow release 1.14.1.

BUG=140423854