### PR TITLE
Add monkey patching of the automl clients

### DIFF
--- a/patches/kaggle_gcp.py
+++ b/patches/kaggle_gcp.py
@@ -176,6 +176,18 @@ def init_bigquery():
             bq_client, *args, **kwargs)
     return bigquery
 
+def monkeypatch_client(client_klass, kaggle_kernel_credentials):
+    client_init = client_klass.__init__
+    def patched_init(self, *args, **kwargs):
+        specified_credentials = kwargs.get('credentials')
+        if specified_credentials is None:
+            Log.info("No credentials specified, using KaggleKernelCredentials.")
+            kwargs['credentials'] = kaggle_kernel_credentials
+        return client_init(self, *args, **kwargs)
+
+    if (not has_been_monkeypatched(client_klass.__init__)):
+        client_klass.__init__ = patched_init
+
 def init_gcs():
     is_user_secrets_token_set = "KAGGLE_USER_SECRETS_TOKEN" in os.environ
     from google.cloud import storage
@@ -188,16 +200,9 @@ def init_gcs():
 
     from kaggle_secrets import GcpTarget
     from kaggle_gcp import KaggleKernelCredentials
-    gcs_client_init = storage.Client.__init__
-    def monkeypatch_gcs(self, *args, **kwargs):
-        specified_credentials = kwargs.get('credentials')
-        if specified_credentials is None:
-            Log.info("No credentials specified, using KaggleKernelCredentials.")
-            kwargs['credentials'] = KaggleKernelCredentials(target=GcpTarget.GCS)
-        return gcs_client_init(self, *args, **kwargs)
-
-    if (not has_been_monkeypatched(storage.Client.__init__)):
-        storage.Client.__init__ = monkeypatch_gcs
+    monkeypatch_client(
+        storage.Client,
+        KaggleKernelCredentials(target=GcpTarget.GCS))
     return storage
 
 def init_automl():
@@ -217,40 +222,14 @@ def init_automl():
     # The AutoML client library exposes 4 different client classes (AutoMlClient,
     # TablesClient, PredictionServiceClient and GcsClient), so patch each of them.
     # The same KaggleKernelCredentials are passed to all of them.
-
-    automl_client_init = automl.AutoMlClient.__init__
-    def monkeypatch_automl(self, *args, **kwargs):
-        specified_credentials = kwargs.get('credentials')
-        if specified_credentials is None:
-            Log.info("No credentials specified, using KaggleKernelCredentials.")
-            kwargs['credentials'] = kaggle_kernel_credentials
-        return automl_client_init(self, *args, **kwargs)
-
-    if (not has_been_monkeypatched(automl.AutoMlClient.__init__)):
-        automl.AutoMlClient.__init__ = monkeypatch_automl
-
-    automl_tablesclient_init = automl.TablesClient.__init__
-    def monkeypatch_tablesclient(self, *args, **kwargs):
-        specified_credentials = kwargs.get('credentials')
-        if specified_credentials is None:
-            Log.info("No credentials specified, using KaggleKernelCredentials.")
-            kwargs['credentials'] = kaggle_kernel_credentials
-        return automl_tablesclient_init(self, *args, **kwargs)
-
-    if (not has_been_monkeypatched(automl.TablesClient.__init__)):
-        automl.TablesClient.__init__ = monkeypatch_tablesclient
-
-    automl_predictionclient_init = automl.PredictionServiceClient.__init__
-    def monkeypatch_predictionclient(self, *args, **kwargs):
-        specified_credentials = kwargs.get('credentials')
-        if specified_credentials is None:
-            Log.info("No credentials specified, using KaggleKernelCredentials.")
-            kwargs['credentials'] = kaggle_kernel_credentials
-        return automl_predictionclient_init(self, *args, **kwargs)
-
-    if (not has_been_monkeypatched(automl.PredictionServiceClient.__init__)):
-        automl.PredictionServiceClient.__init__ = monkeypatch_predictionclient
-
+    monkeypatch_client(automl.AutoMlClient, kaggle_kernel_credentials)
+    monkeypatch_client(automl.TablesClient, kaggle_kernel_credentials)
+    monkeypatch_client(automl.PredictionServiceClient, kaggle_kernel_credentials)
+    # TODO(markcollins): The GcsClient in the AutoML client library version
+    # 0.5.0 doesn't handle credentials properly. I wrote PR:
+    # https://github.com/googleapis/google-cloud-python/pull/9299
+    # to address this issue. Add patching for GcsClient when we get a version of
+    # the library that includes the fixes.
     return automl
 
 def init():

--- a/patches/kaggle_gcp.py
+++ b/patches/kaggle_gcp.py
@@ -224,14 +224,10 @@ def init_automl():
         if specified_credentials is None:
             Log.info("No credentials specified, using KaggleKernelCredentials.")
             kwargs['credentials'] = kaggle_kernel_credentials
-        # Note: This is only here so that unit tests can check whether
-        # credentials were set properly.
-        self._kaggle_credentials = kwargs['credentials']
         return automl_client_init(self, *args, **kwargs)
 
     if (not has_been_monkeypatched(automl.AutoMlClient.__init__)):
         automl.AutoMlClient.__init__ = monkeypatch_automl
-
 
     automl_tablesclient_init = automl.TablesClient.__init__
     def monkeypatch_tablesclient(self, *args, **kwargs):
@@ -239,12 +235,10 @@ def init_automl():
         if specified_credentials is None:
             Log.info("No credentials specified, using KaggleKernelCredentials.")
             kwargs['credentials'] = kaggle_kernel_credentials
-        self._kaggle_credentials = kwargs['credentials']
         return automl_tablesclient_init(self, *args, **kwargs)
 
     if (not has_been_monkeypatched(automl.TablesClient.__init__)):
         automl.TablesClient.__init__ = monkeypatch_tablesclient
-
 
     automl_predictionclient_init = automl.PredictionServiceClient.__init__
     def monkeypatch_predictionclient(self, *args, **kwargs):
@@ -252,7 +246,6 @@ def init_automl():
         if specified_credentials is None:
             Log.info("No credentials specified, using KaggleKernelCredentials.")
             kwargs['credentials'] = kaggle_kernel_credentials
-        self._kaggle_credentials = kwargs['credentials']
         return automl_predictionclient_init(self, *args, **kwargs)
 
     if (not has_been_monkeypatched(automl.PredictionServiceClient.__init__)):

--- a/patches/sitecustomize.py
+++ b/patches/sitecustomize.py
@@ -7,7 +7,7 @@ import importlib
 import importlib.machinery
 
 class GcpModuleFinder(importlib.abc.MetaPathFinder):
-    _MODULES = ['google.cloud.bigquery', 'google.cloud.storage']
+    _MODULES = ['google.cloud.bigquery', 'google.cloud.storage', 'google.cloud.automl_v1beta1']
     _KAGGLE_GCP_PATH = 'kaggle_gcp.py'
     def __init__(self):
         pass
@@ -39,7 +39,8 @@ class GcpModuleLoader(importlib.abc.Loader):
         import kaggle_gcp
         _LOADERS = {
             'google.cloud.bigquery': kaggle_gcp.init_bigquery,
-            'google.cloud.storage': kaggle_gcp.init_gcs
+            'google.cloud.storage': kaggle_gcp.init_gcs,
+            'google.cloud.automl_v1beta1': kaggle_gcp.init_automl,
         }
         monkeypatch_gcp_module = _LOADERS[spec.name]()
         return monkeypatch_gcp_module

--- a/tests/test_automl.py
+++ b/tests/test_automl.py
@@ -1,9 +1,66 @@
 import unittest
 
-from google.cloud import automl_v1beta1 as automl
+from unittest.mock import Mock
+
+from kaggle_gcp import KaggleKernelCredentials, init_automl
+from test.support import EnvironmentVarGuard
+from google.cloud import storage, automl_v1beta1 as automl
+
+def _make_credentials():
+    import google.auth.credentials
+    return Mock(spec=google.auth.credentials.Credentials)
 
 class TestAutoMl(unittest.TestCase):
 
     def test_version(self):
         self.assertIsNotNone(automl.auto_ml_client._GAPIC_LIBRARY_VERSION)
+        version_parts = automl.auto_ml_client._GAPIC_LIBRARY_VERSION.split('.')
+        version = float('.'.join(version_parts[0:2]));
+        self.assertGreaterEqual(version, 0.5);
 
+    def test_user_provided_credentials(self):
+        credentials = _make_credentials()
+        env = EnvironmentVarGuard()
+        env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
+        env.set('KAGGLE_KERNEL_INTEGRATIONS', 'AUTOML')
+        with env:
+            init_automl()
+            client = automl.AutoMlClient(credentials=credentials)
+            self.assertNotIsInstance(client._kaggle_credentials, KaggleKernelCredentials)
+            self.assertIsNotNone(client._kaggle_credentials)
+
+
+    def test_tables_gcs_client(self):
+        # The GcsClient can't currently be monkeypatched for default
+        # credentials because it requires a project which can't be set.
+        # Verify that creating an automl.GcsClient given an actual
+        # storage.Client sets the client properly.
+        gcs_client = storage.Client(project="xyz", credentials=_make_credentials())
+        tables_gcs_client = automl.GcsClient(client=gcs_client)
+        self.assertIs(tables_gcs_client.client, gcs_client)
+
+    def test_default_credentials_automl_enabled(self):
+        env = EnvironmentVarGuard()
+        env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
+        env.set('KAGGLE_KERNEL_INTEGRATIONS', 'AUTOML')
+        with env:
+            init_automl()
+            automl_client = automl.AutoMlClient()
+            self.assertIsNotNone(automl_client._kaggle_credentials)
+            self.assertIsInstance(automl_client._kaggle_credentials, KaggleKernelCredentials)
+            tables_client = automl.TablesClient()
+            self.assertIsNotNone(automl_client._kaggle_credentials)
+            self.assertIsInstance(automl_client._kaggle_credentials, KaggleKernelCredentials)
+            prediction_client = automl.PredictionServiceClient()
+            self.assertIsNotNone(automl_client._kaggle_credentials)
+            self.assertIsInstance(automl_client._kaggle_credentials, KaggleKernelCredentials)
+
+    def test_monkeypatching_idempotent(self):
+        env = EnvironmentVarGuard()
+        env.set('KAGGLE_USER_SECRETS_TOKEN', 'foobar')
+        env.set('KAGGLE_KERNEL_INTEGRATIONS', 'GCS')
+        with env:
+            client1 = automl.AutoMlClient.__init__
+            init_automl()
+            client2 = automl.AutoMlClient.__init__
+            self.assertEqual(client1, client2)


### PR DESCRIPTION
I'm not sure how best to test the credential patching. The AutoML clients don't have a credentials attribute. They pass the credentials 5 layers deep into the gRPC library and it's not clear that the credentials end up as an attribute on any of the objects. I think they just end up captured in a closure.

I added a _kaggle_credentials attribute so that the unit tests can at least verify that the credentials were set in the monkeypatch_XXX functions, but it seems questionable to leave that there in the final image. 

The automl_v1beta1.GcsClient can't be patched because no project is passed in anywhere and setting the credentials without a project causes the underlying storage.Client to try to find a default project in the environment which fails. Passing a storage.Client into the GcsClient constructor works as expected and we've already patched the GcsClient, so that would be the preferred way to set up TablesClient and GcsClient. 

I'm checking for the 0.5.0 or higher library version because that is the latest version and the first version that includes the TablesClient and GcsClient.