### PR TITLE
Add segmentation-models-pytorch package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -492,6 +492,7 @@ RUN pip install flashtext && \
     pip install pytorch-ignite && \
     pip install qgrid && \
     pip install bqplot && \
+    pip install segmentation-models-pytorch && \
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages


### PR DESCRIPTION
Please, add following package with segmentation models for pytorch
 - [segmentation-models-pytorch](https://github.com/qubvel/segmentation_models.pytorch) [![GitHub stars](https://img.shields.io/github/stars/qubvel/segmentation_models.pytorch.svg?logo=github&label=Stars)](https://github.com/qubvel/segmentation_models.pytorch)

It is widely used in current segmentation competitons:
 - [Severstal: Steel DefectDetection](https://www.kaggle.com/c/severstal-steel-defect-detection)
 - [Understanding Clouds from Satellite Images](https://www.kaggle.com/c/understanding_cloud_organization)

Popular discussions and kernels from these competitions which mention/use library:
 - https://www.kaggle.com/artgor/segmentation-in-pytorch-using-convenient-tools (304 likes)
 - https://www.kaggle.com/c/severstal-steel-defect-detection/discussion/103367 (162 likes)