### PR TITLE
Add Docker label with TensorFlow version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_TAG=2019.03
+ARG TENSORFLOW_VERSION=1.14.0
 
-FROM gcr.io/kaggle-images/python-tensorflow-whl:1.14.0-py36 as tensorflow_whl
+FROM gcr.io/kaggle-images/python-tensorflow-whl:${TENSORFLOW_VERSION}-py36 as tensorflow_whl
 FROM continuumio/anaconda3:${BASE_TAG}
 
 ARG GIT_COMMIT=unknown
@@ -8,6 +9,7 @@ ARG BUILD_DATE=unknown
 
 LABEL git-commit=$GIT_COMMIT
 LABEL build-date=$BUILD_DATE
+LABEL tensorflow-version=$TENSORFLOW_VERSION
 
 # Correlate current release with the git hash inside the kernel editor by running `!cat /etc/git_commit`.
 RUN echo "$GIT_COMMIT" > /etc/git_commit && echo "$BUILD_DATE" > /etc/build_date


### PR DESCRIPTION
To easily find an image with the TensorFlow version matching the TPU server version.