### PR TITLE
Pin pytorch/audio and google-cloud-automl to previous working versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -193,6 +193,10 @@ RUN pip install scipy && \
     # PyTorch Audio
     apt-get install -y sox libsox-dev libsox-fmt-all && \
     pip install cffi && \
+    # TODO(b/143372552): Unpin when pytorch/audio is compatible with the version
+    # of pytorch-cpu installed through conda above. A better solution would be to
+    # install torchaudio-cpu in the conda install above when there is a
+    # torchaudio-cpu version that doesn't conflict with pytorch-cpu
     pip install git+git://github.com/pytorch/audio.git@ce1f8aafe63f7d579c74ce54d2a85d452d55c881 && \
     /tmp/clean-layer.sh
 
@@ -342,6 +346,8 @@ RUN pip install --upgrade cython && \
     pip install annoy==1.15.2 && \
     # Need to use CountEncoder from category_encoders before it's officially released
     pip install git+https://github.com/scikit-learn-contrib/categorical-encoding.git && \
+    # TODO(b/143373325) Revert to 0.6.0 to avoid regression in 0.7.0. Go back to
+    # latest when 0.8.0 is released.
     pip install google-cloud-automl==0.6.0 && \
     # Newer version crashes (latest = 1.14.0) when running tensorflow.
     # python -c "from google.cloud import bigquery; import tensorflow". This flow is common because bigquery is imported in kaggle_gcp.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -193,7 +193,7 @@ RUN pip install scipy && \
     # PyTorch Audio
     apt-get install -y sox libsox-dev libsox-fmt-all && \
     pip install cffi && \
-    pip install git+git://github.com/pytorch/audio.git && \
+    pip install git+git://github.com/pytorch/audio.git@ce1f8aafe63f7d579c74ce54d2a85d452d55c881 && \
     /tmp/clean-layer.sh
 
 # vtk with dependencies
@@ -342,7 +342,7 @@ RUN pip install --upgrade cython && \
     pip install annoy==1.15.2 && \
     # Need to use CountEncoder from category_encoders before it's officially released
     pip install git+https://github.com/scikit-learn-contrib/categorical-encoding.git && \
-    pip install google-cloud-automl=0.6.0 && \
+    pip install google-cloud-automl==0.6.0 && \
     # Newer version crashes (latest = 1.14.0) when running tensorflow.
     # python -c "from google.cloud import bigquery; import tensorflow". This flow is common because bigquery is imported in kaggle_gcp.py
     # which is loaded at startup.

--- a/Dockerfile
+++ b/Dockerfile
@@ -342,7 +342,7 @@ RUN pip install --upgrade cython && \
     pip install annoy==1.15.2 && \
     # Need to use CountEncoder from category_encoders before it's officially released
     pip install git+https://github.com/scikit-learn-contrib/categorical-encoding.git && \
-    pip install google-cloud-automl && \
+    pip install google-cloud-automl=0.6.0 && \
     # Newer version crashes (latest = 1.14.0) when running tensorflow.
     # python -c "from google.cloud import bigquery; import tensorflow". This flow is common because bigquery is imported in kaggle_gcp.py
     # which is loaded at startup.


### PR DESCRIPTION
Fixes the build issue with pytorch/audio. This was an issue previously, I submitted issue https://github.com/pytorch/audio/issues/262 and the change was rolled back. The change was rolled forward again on 2019-10-23. We should try to move to a conda install of torchaudio-cpu (along with the current conda install of pytorch-cpu and torchvision-cpu) for CPU-only kernels, but it currently fails with package conflicts.

The other change is to revert google-cloud-automl to the previous version (0.6.0) until they release a version with the fix for https://github.com/googleapis/google-cloud-python/issues/9490 which is currently in flight. This issue impacts the AutoML integration which we are announcing on Nov. 4.