### PR TITLE
Fix fbprophet tests following new pystan version release

### DIFF
--- a/tests/test_fbprophet.py
+++ b/tests/test_fbprophet.py
@@ -13,4 +13,4 @@ class TestFbProphet(unittest.TestCase):
         })
 
         forecaster = Prophet(mcmc_samples=1)
-        forecaster.fit(train)
+        forecaster.fit(train, control={'adapt_engaged': False})


### PR DESCRIPTION
Failure:

```
Traceback (most recent call last):
  File "/input/tests/test_fbprophet.py", line 16, in test_fit
    forecaster.fit(train)
  File "/opt/conda/lib/python3.6/site-packages/fbprophet/forecaster.py", line 1116, in fit
    stan_fit = model.sampling(**args)
  File "/opt/conda/lib/python3.6/site-packages/pystan/model.py", line 756, in sampling
    raise ValueError("Warmup samples must be greater than 0 when adaptation is enabled (`adapt_engaged=True`)")
ValueError: Warmup samples must be greater than 0 when adaptation is enabled (`adapt_engaged=True`)
```

BUG=143471688