### PR TITLE
Update google-cloud-automl to latest version and fix broken test for Catalyst

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -336,9 +336,7 @@ RUN pip install --upgrade cython && \
     pip install annoy==1.15.2 && \
     # Need to use CountEncoder from category_encoders before it's officially released
     pip install git+https://github.com/scikit-learn-contrib/categorical-encoding.git && \
-    # TODO(b/143373325) Revert to 0.6.0 to avoid regression in 0.7.0. Go back to
-    # latest when 0.8.0 is released.
-    pip install google-cloud-automl==0.6.0 && \
+    pip install google-cloud-automl && \
     # Newer version crashes (latest = 1.14.0) when running tensorflow.
     # python -c "from google.cloud import bigquery; import tensorflow". This flow is common because bigquery is imported in kaggle_gcp.py
     # which is loaded at startup.

--- a/tests/test_catalyst.py
+++ b/tests/test_catalyst.py
@@ -146,7 +146,7 @@ class TestCatalyst(unittest.TestCase):
         
         metrics = Safict.load("./logs/checkpoints/_metrics.json")
         metrics_flag1 = \
-            metrics.get("train.2", "loss") < metrics.get("train.0", "loss")
+            metrics.get("train.3", "loss") < metrics.get("train.1", "loss")
         metrics_flag2 = metrics.get("best", "loss") < 0.35
         self.assertTrue(metrics_flag1)
         self.assertTrue(metrics_flag2)


### PR DESCRIPTION
The version of google-cloud-automl was pinned to 0.6.0 to resolve the issue in [b/143373325](http://b/143373325). The fix for the original issue was released in google-cloud-automl 0.7.1. This change removes the pinning and goes back to the latest version of the library.

test_catalyst change: Epoch numbering changed in [Catalyst 19.11](https://github.com/catalyst-team/catalyst/releases/tag/v19.11) (PR: https://github.com/catalyst-team/catalyst/pull/411). The master build is [currently broken](https://ci.kaggle.net/job/kernels/job/docker-python/job/master/626/console) by this issue. 

