### PR TITLE
Add NimbusML python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -490,6 +490,7 @@ RUN pip install flashtext && \
     pip install pytorch-ignite && \
     pip install qgrid && \
     pip install bqplot && \
+    pip install nimbusml && \
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages

--- a/tests/test_nimbusml.py
+++ b/tests/test_nimbusml.py
@@ -1,0 +1,21 @@
+import unittest
+
+from nimbusml import FileDataStream, Pipeline
+from nimbusml.linear_model import FastLinearClassifier
+
+class TestNimbusML(unittest.TestCase):
+
+    def test_nimbusml_pipeline(self):
+        data = FileDataStream.read_csv("/input/tests/data/train.csv", sep=",")
+
+        # train a toy model with three features and two iterations
+        model = Pipeline([
+            FastLinearClassifier(
+                feature=['pixel0', 'pixel1', 'pixel2'],
+                label='label',
+                maximum_number_of_iterations=2
+        )])
+
+        model.fit(data)
+
+        metrics, predictions = model.test(data, output_scores=True)


### PR DESCRIPTION
Fixes #639 

NimbusML provides python bindings for [ML.NET](https://github.com/dotnet/machinelearning/). NimbusML is interoperable with `scikit-learn` estimators and transforms, while adding a suite of fast, highly optimized, and scalable algorithms written in C++ and C#, and also enables out of memory training by streaming data from disk.

Full paper accepted in KDD that shows benchmarks and performance comparisons with `scikit-learn`: https://arxiv.org/pdf/1905.05715.pdf