### PR TITLE
Disable TensorBoard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -543,11 +543,12 @@ ADD patches/sitecustomize.py /root/.local/lib/python3.6/site-packages/sitecustom
 
 # TensorBoard Jupyter extension. Should be replaced with TensorBoard's provided magic once we have
 # worker tunneling support in place.
-ENV JUPYTER_CONFIG_DIR "/root/.jupyter/"
-RUN pip install jupyter_tensorboard && \
-    jupyter serverextension enable jupyter_tensorboard && \
-    jupyter tensorboard enable
-ADD patches/tensorboard/notebook.py /opt/conda/lib/python3.6/site-packages/tensorboard/notebook.py
+# b/139212522 re-enable TensorBoard once solution for slowdown is implemented.
+# ENV JUPYTER_CONFIG_DIR "/root/.jupyter/"
+# RUN pip install jupyter_tensorboard && \
+#     jupyter serverextension enable jupyter_tensorboard && \
+#     jupyter tensorboard enable
+# ADD patches/tensorboard/notebook.py /opt/conda/lib/python3.6/site-packages/tensorboard/notebook.py
 
 # Set backend for matplotlib
 ENV MPLBACKEND "agg"

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -63,4 +63,5 @@ RUN pip install pycuda && \
     /tmp/clean-layer.sh
 
 # Re-add TensorBoard Jupyter extension patch
-ADD patches/tensorboard/notebook.py /opt/conda/lib/python3.6/site-packages/tensorboard/notebook.py
+# b/139212522 re-enable TensorBoard once solution for slowdown is implemented.
+# ADD patches/tensorboard/notebook.py /opt/conda/lib/python3.6/site-packages/tensorboard/notebook.py

--- a/tests/test_jupytertensorboard.py
+++ b/tests/test_jupytertensorboard.py
@@ -2,24 +2,25 @@ import os
 import subprocess
 import unittest
 
-class TestJupyterTensorBoard(unittest.TestCase):
-    def test_jupytertensorboard(self):
-        file_path = os.path.realpath(__file__)
-        ipynb_path = os.path.join(
-            os.path.dirname(file_path), 
-            'data',
-            'jupyter_tensorboard.ipynb',
-        )
+# b/139212522 re-enable TensorBoard once solution for slowdown is implemented.
+# class TestJupyterTensorBoard(unittest.TestCase):   
+#     def test_jupytertensorboard(self):
+#         file_path = os.path.realpath(__file__)
+#         ipynb_path = os.path.join(
+#             os.path.dirname(file_path), 
+#             'data',
+#             'jupyter_tensorboard.ipynb',
+#         )
 
-        result = subprocess.run([
-                'jupyter',
-                'nbconvert',
-                '--execute',
-                '--stdout',
-                ipynb_path,
-            ],
-            stdout=subprocess.PIPE
-        )
+#         result = subprocess.run([
+#                 'jupyter',
+#                 'nbconvert',
+#                 '--execute',
+#                 '--stdout',
+#                 ipynb_path,
+#             ],
+#             stdout=subprocess.PIPE
+#         )
 
-        self.assertTrue(result.returncode == 0)
-        self.assertTrue(b'JUPYTER_TENSORBOARD_TEST_MARKER' in result.stdout)
+#         self.assertTrue(result.returncode == 0)
+#         self.assertTrue(b'JUPYTER_TENSORBOARD_TEST_MARKER' in result.stdout)


### PR DESCRIPTION
TensorBoard adds anywhere from 4s to 10s+ latency when starting any Python Notebook.

Re-enable TensorBoard once a solution to enable TensorBoard only when a user uses it is implemented.

BUG=139212522
 