### PR TITLE
add clustergrammer2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -489,6 +489,7 @@ RUN pip install flashtext && \
     pip install pytorch-ignite && \
     pip install qgrid && \
     pip install bqplot && \
+    pip install clustergrammer2 && \    
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages


### PR DESCRIPTION
Clustergrammer2 is an interactive WebGL heatmap Widget for clustering and visualizing high-dimensional data (e.g. Pandas DataFrame) that runs in Kaggle. 

See examples: 

https://www.kaggle.com/cornhundred/heatmap-view-of-modern-era-nba-player-stats

https://github.com/ismms-himc/clustergrammer2-notebooks