### PR TITLE
add google earth engine API to default Kaggle docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -489,6 +489,7 @@ RUN pip install flashtext && \
     pip install pytorch-ignite && \
     pip install qgrid && \
     pip install bqplot && \
+    pip install earthengine-api && \
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages

--- a/tests/test_earthengine.py
+++ b/tests/test_earthengine.py
@@ -1,0 +1,6 @@
+import unittest
+import ee
+
+class TestEarthEngine(unittest.TestCase):
+    def test_version(self):
+        self.assertIsNotNone(ee.__version__)


### PR DESCRIPTION
We would like to install the Google Earth Engine API on the default Kaggle docker image.  I did not write any tests for this API because the API requires private credentials.  I was able to successfully ./build the DockerFile but I was not able to successfully ./test the DockerFile (because "FAIL: test_version (test_gcloud.TestGcloud)").