### PR TITLE
Build TensorFlow 2.1.0 whl

### DIFF
--- a/tensorflow-whl/CHANGELOG.md
+++ b/tensorflow-whl/CHANGELOG.md
@@ -7,5 +7,6 @@
 1.14.0-py36: TensorFlow 1.14.0 with Python 3.6
 2.0.0-rc1-py36: TensorFlow 2.0.0 RC1 with Python 3.6
 2.0.0-py36: TensorFlow 2.0.0 with Python 3.6
-2.1.0-rc0-py36: TensorFlow 2.0.1-rc0 with Python 3.6
-2.1.0-rc2-py36: TensorFlow 2.0.1-rc2 with Python 3.6
+2.1.0-rc0-py36: TensorFlow 2.1.0-rc0 with Python 3.6
+2.1.0-rc2-py36: TensorFlow 2.1.0-rc2 with Python 3.6
+2.1.0-py36: TensorFlow 2.1.0 with Python 3.6

--- a/tensorflow-whl/Dockerfile
+++ b/tensorflow-whl/Dockerfile
@@ -62,7 +62,7 @@ RUN apt-get install -y gnupg zip openjdk-8-jdk && \
 RUN cd /usr/local/src && \
     git clone https://github.com/tensorflow/tensorflow && \
     cd tensorflow && \
-    git checkout tags/v2.1.0-rc2 && \
+    git checkout tags/v2.1.0 && \
     pip install keras_applications --no-deps && \
     pip install keras_preprocessing --no-deps
 


### PR DESCRIPTION
TensorFlow 2.1.0 GA was released on 1/9/2020.