### PR TITLE
Add a Kaggle dataset client to support getting GCS paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -532,6 +532,8 @@ RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.c
 ENV PYTHONUSERBASE "/root/.local"
 ADD patches/kaggle_gcp.py /root/.local/lib/python3.6/site-packages/kaggle_gcp.py
 ADD patches/kaggle_secrets.py /root/.local/lib/python3.6/site-packages/kaggle_secrets.py
+ADD patches/kaggle_web_client.py /root/.local/lib/python3.6/site-packages/kaggle_web_client.py
+ADD patches/kaggle_datasets.py /root/.local/lib/python3.6/site-packages/kaggle_datasets.py
 ADD patches/log.py /root/.local/lib/python3.6/site-packages/log.py
 ADD patches/sitecustomize.py /root/.local/lib/python3.6/site-packages/sitecustomize.py
 

--- a/patches/kaggle_datasets.py
+++ b/patches/kaggle_datasets.py
@@ -1,0 +1,24 @@
+import os
+from kaggle_web_client import KaggleWebClient
+
+_KAGGLE_TPU_NAME_ENV_VAR_NAME = 'TPU_NAME'
+
+class KaggleDatasets:
+    GET_GCS_PATH_ENDPOINT = '/requests/CopyDatasetVersionToKnownGcsBucketRequest'
+
+    # Integration types for GCS
+    AUTO_ML = 1
+    TPU = 2
+
+    def __init__(self):
+        self.web_client = KaggleWebClient()
+        self.has_tpu = os.getenv(_KAGGLE_TPU_NAME_ENV_VAR_NAME) is not None
+
+    def get_gcs_path(self, dataset_dir: str = None) -> str:
+        integration_type = self.TPU if self.has_tpu else self.AUTO_ML
+        data = {
+            'MountSlug': dataset_dir,
+            'IntegrationType': integration_type,
+        }
+        result = self.web_client.make_post_request(data, self.GET_GCS_PATH_ENDPOINT)
+        return result['destinationBucket']

--- a/patches/kaggle_secrets.py
+++ b/patches/kaggle_secrets.py
@@ -67,6 +67,8 @@ class UserSecretsClient():
         self.headers = {'Content-type': 'application/json'}
 
     def _make_post_request(self, data: dict, endpoint: str = GET_USER_SECRET_ENDPOINT) -> dict:
+        # TODO(b/148309982) This code and the code in the constructor should be
+        # removed and this class should use the new KaggleWebClient class instead.
         url = f'{self.url_base}{endpoint}'
         request_body = dict(data)
         request_body['JWE'] = self.jwt_token

--- a/patches/kaggle_web_client.py
+++ b/patches/kaggle_web_client.py
@@ -1,4 +1,3 @@
-
 import json
 import os
 import socket

--- a/patches/kaggle_web_client.py
+++ b/patches/kaggle_web_client.py
@@ -1,0 +1,58 @@
+
+import json
+import os
+import socket
+import urllib.request
+from datetime import datetime, timedelta
+from enum import Enum, unique
+from typing import Optional, Tuple
+from urllib.error import HTTPError, URLError
+from kaggle_secrets import (_KAGGLE_DEFAULT_URL_BASE,
+                            _KAGGLE_URL_BASE_ENV_VAR_NAME,
+                            _KAGGLE_USER_SECRETS_TOKEN_ENV_VAR_NAME,
+                            CredentialError, BackendError, ValidationError)
+
+class KaggleWebClient:
+    TIMEOUT_SECS = 90
+
+    def __init__(self):
+        url_base_override = os.getenv(_KAGGLE_URL_BASE_ENV_VAR_NAME)
+        self.url_base = url_base_override or _KAGGLE_DEFAULT_URL_BASE
+        # Follow the OAuth 2.0 Authorization standard (https://tools.ietf.org/html/rfc6750)
+        self.jwt_token = os.getenv(_KAGGLE_USER_SECRETS_TOKEN_ENV_VAR_NAME)
+        if self.jwt_token is None:
+            raise CredentialError(
+                'A JWT Token is required to call Kaggle, '
+                f'but none found in environment variable {_KAGGLE_USER_SECRETS_TOKEN_ENV_VAR_NAME}')
+        self.headers = {
+            'Content-type': 'application/json',
+            'Authorization': f'Bearer {self.jwt_token}',
+        }
+
+    def make_post_request(self, data: dict, endpoint: str) -> dict:
+        url = f'{self.url_base}{endpoint}'
+        request_body = dict(data)
+        request_body['JWE'] = self.jwt_token
+        req = urllib.request.Request(url, headers=self.headers, data=bytes(
+            json.dumps(request_body), encoding="utf-8"))
+        try:
+            with urllib.request.urlopen(req, timeout=self.TIMEOUT_SECS) as response:
+                response_json = json.loads(response.read())
+                if not response_json.get('wasSuccessful') or 'result' not in response_json:
+                    raise BackendError(
+                        f'Unexpected response from the service. Response: {response_json}.')
+                return response_json['result']
+        except (URLError, socket.timeout) as e:
+            if isinstance(
+                    e, socket.timeout) or isinstance(
+                    e.reason, socket.timeout):
+                raise ConnectionError(
+                    'Timeout error trying to communicate with service. Please ensure internet is on.') from e
+            raise ConnectionError(
+                'Connection error trying to communicate with service.') from e
+        except HTTPError as e:
+            if e.code == 401 or e.code == 403:
+                raise CredentialError(
+                    f'Service responded with error code {e.code}.'
+                    ' Please ensure you have access to the resource.') from e
+            raise BackendError('Unexpected response from the service.') from e

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -5,11 +5,7 @@ import unittest
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from test.support import EnvironmentVarGuard
 from urllib.parse import urlparse
-from datetime import datetime, timedelta
-import mock
 
-from google.auth.exceptions import DefaultCredentialsError
-from google.cloud import bigquery
 from kaggle_secrets import (_KAGGLE_URL_BASE_ENV_VAR_NAME,
                             _KAGGLE_USER_SECRETS_TOKEN_ENV_VAR_NAME,
                             CredentialError, BackendError, ValidationError)
@@ -107,7 +103,8 @@ class TestDatasets(unittest.TestCase):
             gcs_path = client.get_gcs_path()
             self.assertEqual(gcs_path, _TPU_GCS_BUCKET)
         self._test_client(call_get_gcs_path,
-                          '/requests/CopyDatasetVersionToKnownGcsBucketRequest', {'MountSlug': None, 'IntegrationType': 2, 'JWE': _TEST_JWT},
+                          '/requests/CopyDatasetVersionToKnownGcsBucketRequest',
+                          {'MountSlug': None, 'IntegrationType': 2, 'JWE': _TEST_JWT},
                           is_tpu=True)
 
     def test_get_gcs_path_automl_succeeds(self):
@@ -116,7 +113,8 @@ class TestDatasets(unittest.TestCase):
             gcs_path = client.get_gcs_path()
             self.assertEqual(gcs_path, _AUTOML_GCS_BUCKET)
         self._test_client(call_get_gcs_path,
-                          '/requests/CopyDatasetVersionToKnownGcsBucketRequest', {'MountSlug': None, 'IntegrationType': 1, 'JWE': _TEST_JWT},
+                          '/requests/CopyDatasetVersionToKnownGcsBucketRequest',
+                          {'MountSlug': None, 'IntegrationType': 1, 'JWE': _TEST_JWT},
                           is_tpu=False)
 
     def test_get_gcs_path_handles_unsuccessful(self):
@@ -125,6 +123,7 @@ class TestDatasets(unittest.TestCase):
             with self.assertRaises(BackendError):
                 gcs_path = client.get_gcs_path()
         self._test_client(call_get_gcs_path,
-                          '/requests/CopyDatasetVersionToKnownGcsBucketRequest', {'MountSlug': None, 'IntegrationType': 2, 'JWE': _TEST_JWT},
+                          '/requests/CopyDatasetVersionToKnownGcsBucketRequest',
+                          {'MountSlug': None, 'IntegrationType': 2, 'JWE': _TEST_JWT},
                           is_tpu=True,
                           success=False)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,130 @@
+import json
+import os
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from test.support import EnvironmentVarGuard
+from urllib.parse import urlparse
+from datetime import datetime, timedelta
+import mock
+
+from google.auth.exceptions import DefaultCredentialsError
+from google.cloud import bigquery
+from kaggle_secrets import (_KAGGLE_URL_BASE_ENV_VAR_NAME,
+                            _KAGGLE_USER_SECRETS_TOKEN_ENV_VAR_NAME,
+                            CredentialError, BackendError, ValidationError)
+from kaggle_web_client import KaggleWebClient
+from kaggle_datasets import KaggleDatasets, _KAGGLE_TPU_NAME_ENV_VAR_NAME
+
+_TEST_JWT = 'test-secrets-key'
+
+_TPU_GCS_BUCKET = 'gs://kds-tpu-ea1971a458ffd4cd51389e7574c022ecc0a82bb1b52ccef08c8a'
+_AUTOML_GCS_BUCKET = 'gs://kds-automl-ea1971a458ffd4cd51389e7574c022ecc0a82bb1b52ccef08c8a'
+
+class GcsDatasetsHTTPHandler(BaseHTTPRequestHandler):
+
+    def set_request(self):
+        raise NotImplementedError()
+
+    def get_response(self):
+        raise NotImplementedError()
+
+    def do_HEAD(s):
+        s.send_response(200)
+
+    def do_POST(s):
+        s.set_request()
+        s.send_response(200)
+        s.send_header("Content-type", "application/json")
+        s.end_headers()
+        s.wfile.write(json.dumps(s.get_response()).encode("utf-8"))
+
+
+class TestDatasets(unittest.TestCase):
+    SERVER_ADDRESS = urlparse(os.getenv(_KAGGLE_URL_BASE_ENV_VAR_NAME, default="http://127.0.0.1:8001"))
+
+    def _test_client(self, client_func, expected_path, expected_body, is_tpu=True, success=True):
+        _request = {}
+
+        class GetGcsPathHandler(GcsDatasetsHTTPHandler):
+
+            def set_request(self):
+                _request['path'] = self.path
+                content_len = int(self.headers.get('Content-Length'))
+                _request['body'] = json.loads(self.rfile.read(content_len))
+                _request['headers'] = self.headers
+
+            def get_response(self):
+                if success:
+                    gcs_path = _TPU_GCS_BUCKET if is_tpu else _AUTOML_GCS_BUCKET
+                    return {'result': {
+                        'destinationBucket': gcs_path,
+                        'destinationPath': None}, 'wasSuccessful': "true"}
+                else:
+                    return {'wasSuccessful': "false"}
+
+        env = EnvironmentVarGuard()
+        env.set(_KAGGLE_USER_SECRETS_TOKEN_ENV_VAR_NAME, _TEST_JWT)
+        if is_tpu:
+          env.set(_KAGGLE_TPU_NAME_ENV_VAR_NAME, 'FAKE_TPU')
+        with env:
+            with HTTPServer((self.SERVER_ADDRESS.hostname, self.SERVER_ADDRESS.port), GetGcsPathHandler) as httpd:
+                threading.Thread(target=httpd.serve_forever).start()
+
+                try:
+                    client_func()
+                finally:
+                    httpd.shutdown()
+
+                path, headers, body = _request['path'], _request['headers'], _request['body']
+                self.assertEqual(
+                    path,
+                    expected_path,
+                    msg="Fake server did not receive the right request from the KaggleDatasets client.")
+                self.assertEqual(
+                    body,
+                    expected_body,
+                    msg="Fake server did not receive the right body from the KaggleDatasets client.")
+                self.assertIn('Content-Type', headers.keys(),
+                    msg="Fake server did not receive a Content-Type header from the KaggleDatasets client.")
+                self.assertEqual('application/json', headers.get('Content-Type'),
+                    msg="Fake server did not receive an application/json content type header from the KaggleDatasets client.")
+                self.assertIn('Authorization', headers.keys(),
+                    msg="Fake server did not receive an Authorization header from the KaggleDatasets client.")
+                self.assertEqual(f'Bearer {_TEST_JWT}', headers.get('Authorization'),
+                    msg="Fake server did not receive the right Authorization header from the KaggleDatasets client.")
+
+    def test_no_token_fails(self):
+        env = EnvironmentVarGuard()
+        env.unset(_KAGGLE_USER_SECRETS_TOKEN_ENV_VAR_NAME)
+        with env:
+            with self.assertRaises(CredentialError):
+                client = KaggleDatasets()
+
+    def test_get_gcs_path_tpu_succeeds(self):
+        def call_get_gcs_path():
+            client = KaggleDatasets()
+            gcs_path = client.get_gcs_path()
+            self.assertEqual(gcs_path, _TPU_GCS_BUCKET)
+        self._test_client(call_get_gcs_path,
+                          '/requests/CopyDatasetVersionToKnownGcsBucketRequest', {'MountSlug': None, 'IntegrationType': 2, 'JWE': _TEST_JWT},
+                          is_tpu=True)
+
+    def test_get_gcs_path_automl_succeeds(self):
+        def call_get_gcs_path():
+            client = KaggleDatasets()
+            gcs_path = client.get_gcs_path()
+            self.assertEqual(gcs_path, _AUTOML_GCS_BUCKET)
+        self._test_client(call_get_gcs_path,
+                          '/requests/CopyDatasetVersionToKnownGcsBucketRequest', {'MountSlug': None, 'IntegrationType': 1, 'JWE': _TEST_JWT},
+                          is_tpu=False)
+
+    def test_get_gcs_path_handles_unsuccessful(self):
+        def call_get_gcs_path():
+            client = KaggleDatasets()
+            with self.assertRaises(BackendError):
+                gcs_path = client.get_gcs_path()
+        self._test_client(call_get_gcs_path,
+                          '/requests/CopyDatasetVersionToKnownGcsBucketRequest', {'MountSlug': None, 'IntegrationType': 2, 'JWE': _TEST_JWT},
+                          is_tpu=True,
+                          success=False)


### PR DESCRIPTION
This will support TPUs and AutoML for now. The new `kaggle_web_client.py` file is a copy of the request code currently in `kaggle_secrets.py`. The intent is to follow up and move the shared constants (`_KAGGLE_*`) from kaggle_secrets and have both files use the common code in kaggle_web_client. Given the tight deadline, I didn't want to introduce unnecesary changes in this PR which could break integrations that are already launched.