### PR TITLE
Increase the timeout for potentially slow web request

### DIFF
--- a/patches/kaggle_web_client.py
+++ b/patches/kaggle_web_client.py
@@ -12,7 +12,7 @@ from kaggle_secrets import (_KAGGLE_DEFAULT_URL_BASE,
                             CredentialError, BackendError, ValidationError)
 
 class KaggleWebClient:
-    TIMEOUT_SECS = 90
+    TIMEOUT_SECS = 600
 
     def __init__(self):
         url_base_override = os.getenv(_KAGGLE_URL_BASE_ENV_VAR_NAME)


### PR DESCRIPTION
A short-term workaround for [b/148937154](http://b/148937154) until [b/148790385](https://b.corp.google.com/issues/148790385) can be implemented.

Increases the timeout on the web request backing the get_gcs_path function from 90 seconds to 600 seconds. This should cut down on the timeouts that we've seen in testing.