### PR TITLE
Install latest version of pip.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,7 @@ RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list &
     apt-get update && apt-get install -y build-essential unzip cmake && \
     # Work to upgrade to Python 3.7 can be found on this branch: https://github.com/Kaggle/docker-python/blob/upgrade-py37/Dockerfile
     conda install -y python=3.6.6 && \
-    # See b/148097039#comment7
-    pip install pip==19.3.1 && \
+    pip install --upgrade pip && \
     /tmp/clean-layer.sh
 
 # The anaconda base image includes outdated versions of these packages. Update them to include the latest version.


### PR DESCRIPTION
We added the pining because pip `20.0.1` introduced an issue with wheels tag matching. See b/148097039.

pip `20.0.2` has since been released and fixes the issue: 
https://github.com/pypa/pip/issues/7626