### PR TITLE
Unpin wand

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -489,7 +489,7 @@ RUN pip install flashtext && \
 # Tesseract and some associated utility packages
 RUN apt-get install tesseract-ocr -y && \
     pip install pytesseract && \
-    pip install wand==0.5.3 && \
+    pip install wand && \
     pip install pdf2image && \
     pip install PyPDF && \
     pip install pyocr && \


### PR DESCRIPTION
`pytesseract ` was incompatible with `wand` version `0.5.4` but now works with the latest version of `wand` (0.5.8).