### PR TITLE
Fix automl version test check

### DIFF
--- a/tests/test_automl.py
+++ b/tests/test_automl.py
@@ -14,6 +14,7 @@ class TestAutoMl(unittest.TestCase):
 
     def test_version(self):
         self.assertIsNotNone(automl.auto_ml_client._GAPIC_LIBRARY_VERSION)
+        # follows semver (i.e. major.minor.patch)
         version_parts = automl.auto_ml_client._GAPIC_LIBRARY_VERSION.split('.')
         self.assertEqual(3, len(version_parts))
         # Ensures that version is >= 0.5

--- a/tests/test_automl.py
+++ b/tests/test_automl.py
@@ -15,8 +15,12 @@ class TestAutoMl(unittest.TestCase):
     def test_version(self):
         self.assertIsNotNone(automl.auto_ml_client._GAPIC_LIBRARY_VERSION)
         version_parts = automl.auto_ml_client._GAPIC_LIBRARY_VERSION.split('.')
-        version = float('.'.join(version_parts[0:2]));
-        self.assertGreaterEqual(version, 0.5);
+        self.assertEqual(3, len(version_parts))
+        # Ensures that version is >= 0.5
+        major = version_parts[0]
+        minor = version_parts[1]
+        if major == 0:
+            self.assertGreaterEqual(5, minor)
 
     class FakeClient:
         def __init__(self, credentials=None, client_info=None, **kwargs):

--- a/tests/test_automl.py
+++ b/tests/test_automl.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 from kaggle_gcp import KaggleKernelCredentials, init_automl
 from test.support import EnvironmentVarGuard
 from google.cloud import storage, automl_v1beta1 as automl
+from packaging.version import parse
 
 def _make_credentials():
     import google.auth.credentials
@@ -14,14 +15,7 @@ class TestAutoMl(unittest.TestCase):
 
     def test_version(self):
         self.assertIsNotNone(automl.auto_ml_client._GAPIC_LIBRARY_VERSION)
-        # follows semver (i.e. major.minor.patch)
-        version_parts = automl.auto_ml_client._GAPIC_LIBRARY_VERSION.split('.')
-        self.assertEqual(3, len(version_parts))
-        # Ensures that version is >= 0.5
-        major = int(version_parts[0])
-        minor = int(version_parts[1])
-        if major == 0:
-            self.assertGreaterEqual(minor, 5)
+        self.assertGreaterEqual(parse(automl.auto_ml_client._GAPIC_LIBRARY_VERSION), parse("0.5.0"))
 
     class FakeClient:
         def __init__(self, credentials=None, client_info=None, **kwargs):

--- a/tests/test_automl.py
+++ b/tests/test_automl.py
@@ -17,10 +17,10 @@ class TestAutoMl(unittest.TestCase):
         version_parts = automl.auto_ml_client._GAPIC_LIBRARY_VERSION.split('.')
         self.assertEqual(3, len(version_parts))
         # Ensures that version is >= 0.5
-        major = version_parts[0]
-        minor = version_parts[1]
+        major = int(version_parts[0])
+        minor = int(version_parts[1])
         if major == 0:
-            self.assertGreaterEqual(5, minor)
+            self.assertGreaterEqual(minor, 5)
 
     class FakeClient:
         def __init__(self, credentials=None, client_info=None, **kwargs):


### PR DESCRIPTION
Version 0.10.0 was released an hour ago which caused the tests to start failing.

The current check was converting `0.10` to a float (becomes `0.1`) which is less than `0.5`.