### PR TITLE
Prevent spacy downgrade by allennlp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -410,6 +410,8 @@ RUN pip install bcolz && \
     pip install fastai && \
     pip install torchtext && \
     pip install allennlp && \
+    # b/149359379 remove once allennlp 1.0 is released which won't cause a spacy downgrade.
+    pip install spacy==2.2.3 && \
     /tmp/clean-layer.sh
 
     ###########


### PR DESCRIPTION
#708 removed the manual install of allennlp dependencies which caused a downgrade of spacy. The constraint set is too strict. It is still working with spacy 2.2.3