### PR TITLE
Adds pyspark package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -470,6 +470,8 @@ RUN pip install flashtext && \
     pip install earthengine-api && \
     pip install transformers && \
     pip install kaggle-environments && \
+    # PySpark package
+    pip install pyspark && \
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages

--- a/test
+++ b/test
@@ -87,7 +87,7 @@ fi
 # By default, TensorFlow maps nearly all of the GPU memory visible to the process.
 # This is causing issue when other libraries are trying to run tests using a GPU.
 # See: https://www.tensorflow.org/guide/gpu#allowing_gpu_memory_growth
-docker run --rm -t --read-only --net=none \
+docker run --rm -t --read-only --net=bridge \
     -e HOME=/tmp -e KAGGLE_DATA_PROXY_TOKEN=test-key \
     -e KAGGLE_USER_SECRETS_TOKEN_KEY=test-secrets-key \
     -e KAGGLE_URL_BASE=http://127.0.0.1:8001 \
@@ -100,4 +100,4 @@ docker run --rm -t --read-only --net=none \
     -w=/working \
     $ADDITONAL_OPTS \
     "$IMAGE_TAG" \
-    /bin/bash -c "python -m unittest discover -s /input/tests -p $PATTERN -v"
+    /bin/bash -c "cd /input/tests && python -m unittest discover -s /input/tests -p \"$PATTERN\" -v"

--- a/tests/test_pyspark.py
+++ b/tests/test_pyspark.py
@@ -1,0 +1,37 @@
+import unittest
+
+import math
+import random
+
+import pyspark
+
+ss = pyspark.sql.SparkSession.builder\
+    .appName('pyspark_pi_calculator')\
+    .getOrCreate()
+
+
+# Obtain Spark Context object
+sc = ss.sparkContext
+
+
+# Reference:
+# 'Pi Estimation' example adopted from: https://spark.apache.org/examples.html
+
+def inside(p):
+    '''
+    Tells whether a random point is inside a unit circle.
+    '''
+    x, y = random.random(), random.random()
+    return x*x + y*y < 1
+
+
+class TestPyspark(unittest.TestCase):
+    def test_calculate_pi(self):
+        global sc
+
+        num_samples = 100000000
+        count = sc.parallelize(range(0, num_samples)).filter(inside).count()
+        pyspark_pi = 4.0 * count / num_samples
+
+        self.assertAlmostEqual(pyspark_pi, math.pi, places=2)
+


### PR DESCRIPTION
In this PR, we add instructions to Dockerfile to make `pyspark` package available in kaggle kernel.

Specifically, this PR:
* Installs pyspark package via pip.
* Adds a provided example (PI estimator) as a test case to test pyspark functionality.
