### PR TITLE
Remove unsupported parameters in geoviews test

### DIFF
--- a/tests/test_geoviews.py
+++ b/tests/test_geoviews.py
@@ -7,5 +7,5 @@ from cartopy import crs
 class TestGeoviews(unittest.TestCase):
     def test_viz(self):
         (gf.ocean + gf.land + gf.ocean * gf.land * gf.coastline * gf.borders).options(
-            'Feature', projection=crs.Geostationary(), global_extent=True, height=325
+            'Feature', projection=crs.Geostationary(), global_extent=True
         ).cols(3)


### PR DESCRIPTION
The `height` option is not valid for the `matplotlib` backend.

It has been a warning for a little while but is now an error and makes our test fail:

```
WARNING:param.main: Option 'height' for Feature type not valid for selected backend ('matplotlib'). Option only applies to following backends: ['bokeh']
```

BUG=151656948