### PR TITLE
Bump jaxlib version to fix build error

### DIFF
--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -74,7 +74,7 @@ ENV JAX_CUDA_VERSION=cuda$CUDA_MAJOR_VERSION$CUDA_MINOR_VERSION
 ENV JAX_PLATFORM=linux_x86_64
 ENV JAX_BASE_URL="https://storage.googleapis.com/jax-releases"
 
-RUN  pip install --upgrade $JAX_BASE_URL/$JAX_CUDA_VERSION/jaxlib-0.1.38-$JAX_PYTHON_VERSION-none-$JAX_PLATFORM.whl && \
+RUN  pip install --upgrade $JAX_BASE_URL/$JAX_CUDA_VERSION/jaxlib-0.1.41-$JAX_PYTHON_VERSION-none-$JAX_PLATFORM.whl && \
      pip install --upgrade jax
 
 # Reinstall packages with a separate version for GPU support.


### PR DESCRIPTION
Fixes `ValueError: jaxlib is version 0.1.38, but this version of jax requires version 0.1.41.` error during docker-python build