### PR TITLE
Remove dev libraries no longer needed since we install basemap via co…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,8 +113,7 @@ RUN apt-get install -y libfreetype6-dev && \
 # Make sure the dynamic linker finds the right libstdc++
 ENV LD_LIBRARY_PATH=/opt/conda/lib
 
-RUN apt-get -y install zlib1g-dev liblcms2-dev libwebp-dev libgeos-dev && \
-    pip install matplotlib && \
+RUN pip install matplotlib && \
     pip install pyshp && \
     pip install pyproj && \
     conda install basemap && \


### PR DESCRIPTION
…nda instead of from source. They were left here https://github.com/Kaggle/docker-python/commit/8e330545f53102dab11063be049d82c4dd3b4139