### PR TITLE
Add config to skip deep conda dep checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,9 @@ RUN apt-get install -y libfreetype6-dev && \
 # Make sure the dynamic linker finds the right libstdc++
 ENV LD_LIBRARY_PATH=/opt/conda/lib
 
+# Disable deep conda dependency checks
+RUN conda config --set unsatisfiable_hints_check_depth 1
+
 RUN apt-get -y install zlib1g-dev liblcms2-dev libwebp-dev libgeos-dev && \
     pip install matplotlib && \
     pip install pyshp && \


### PR DESCRIPTION
Seems that conda fails due to deep dependency conflicts, started without changing much on our side. Looks like they recently added `unsatisfiable_hints_check_depth` (https://github.com/conda/conda/pull/9560/files) which can be configured to do more shallow checks. This PR does exactly that.