### PR TITLE
Remove tflearn package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -208,8 +208,6 @@ RUN pip install mpld3 && \
     pip install plotly && \
     pip install git+https://github.com/nicta/dora.git && \
     pip install git+https://github.com/hyperopt/hyperopt.git && \
-    # tflean. Deep learning library featuring a higher-level API for TensorFlow. http://tflearn.org
-    pip install git+https://github.com/tflearn/tflearn.git && \
     pip install fitter && \
     pip install langid && \
     # Delorean. Useful for dealing with datetime


### PR DESCRIPTION
This package is unmaintained and hasn't been updated since 2017. Keras is now the preferred high-level library for writing TensorFlow code.

Additionally, this package was broken because it requires TensorFlow 1.x and we are using 2.x

BUG=152539178