### PR TITLE
Remove dora package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -206,7 +206,6 @@ RUN pip install mpld3 && \
     pip install toolz cytoolz && \
     pip install sacred && \
     pip install plotly && \
-    pip install git+https://github.com/nicta/dora.git && \
     pip install git+https://github.com/hyperopt/hyperopt.git && \
     # tflean. Deep learning library featuring a higher-level API for TensorFlow. http://tflearn.org
     pip install git+https://github.com/tflearn/tflearn.git && \


### PR DESCRIPTION
Usage: 0 kernels per day

Rational:

Unmaintained, hasn't been updated since 2016, no usage. 10 stars on GitHub.