### PR TITLE
Remove hallucinate package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -279,7 +279,6 @@ RUN pip install mpld3 && \
     # plotnine 0.5 is depending on matplotlib >= 3.0 which is not compatible with basemap.
     # once basemap support matplotlib, we can unpin this package.
     pip install plotnine==0.4.0 && \
-    pip install git+https://github.com/dvaida/hallucinate.git && \
     pip install scikit-surprise && \
     pip install pymongo && \
     pip install edward && \


### PR DESCRIPTION
Usage: 0 kernels per day.

Rational:

Unmaintained (last commit 2017), 0 GitHub stars, originally added to our Docker image by the package author.