### PR TITLE
Remove vega3 package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -334,9 +334,6 @@ RUN pip install --upgrade cython && \
     # yellowbrick machine learning visualization library
     pip install yellowbrick && \
     pip install mlcrate && \
-    # Required to display Altair charts in Jupyter notebook
-    pip install vega3 && \
-    jupyter nbextension install --sys-prefix --py vega3 && \
     /tmp/clean-layer.sh
 
 # Fast.ai and dependencies


### PR DESCRIPTION
Usage: 0 kernels per day.

Rational:

Unmaintained. Deprecated in favor of vega. Low GitHub stars, will consider add vega if > 1000 stars and if someone ask for it.

Some people are using Altair which requires vega to display the chart. It requires `vega` and not `vega3`. People are using the `pip install` workaround which is the preferred way to do for not very popular packages that are not required in KO competitions. See:
https://www.kaggle.com/general/63534