### PR TITLE
Remove edward package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -272,7 +272,6 @@ RUN pip install mpld3 && \
     pip install plotnine==0.4.0 && \
     pip install scikit-surprise && \
     pip install pymongo && \
-    pip install edward && \
     pip install geoplot && \
     pip install eli5 && \
     pip install implicit && \


### PR DESCRIPTION
Unmaintained (last commit in 2018). `edward` is a probabilistic programming language built on top of TensorFlow 1.x. This doesn't work with TensorFlow 2.x which means this package is effectively broken.

BUG=152539178