### PR TITLE
Remove glmnet-py package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -292,7 +292,6 @@ RUN pip install kmeans-smote --no-dependencies && \
     pip install fbpca && \
     pip install sentencepiece && \
     pip install cufflinks && \
-    pip install glmnet_py && \
     pip install lime && \
     pip install memory_profiler && \
     /tmp/clean-layer.sh


### PR DESCRIPTION
Unmaintained (last updated in 2017). This is a fork of the Stanford `glmnet` package. The `glmnet` packages is still maintained but has a low # of stars on GitHub. We can consider adding the `glmnet` package if it attracts > 1000 stars and if someone asks for it.

BUG=152539178