### PR TITLE
Remove pykoko package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -319,7 +319,6 @@ RUN pip install --upgrade cython && \
     pip install scattertext && \
     # Pandas data reader
     pip install pandas-datareader && \
-    pip install pykoko && \
     pip install wordsegment && \
     pip install pyahocorasick && \
     pip install wordbatch && \


### PR DESCRIPTION
Usage: 0 kernels / day

Rational:

Unmaintained (last updated in 2017), only 12 GitHub stars, no usage.

Our users can install it with `pip install` if they ever need to.

BUG=152539178