### PR TITLE
Install hyperopt using pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -199,7 +199,7 @@ RUN pip install mpld3 && \
     pip install toolz cytoolz && \
     pip install sacred && \
     pip install plotly && \
-    pip install git+https://github.com/hyperopt/hyperopt.git && \
+    pip install hyperopt && \
     pip install fitter && \
     pip install langid && \
     # Delorean. Useful for dealing with datetime

--- a/tests/test_hyperopt.py
+++ b/tests/test_hyperopt.py
@@ -1,0 +1,13 @@
+import unittest
+
+from hyperopt import fmin, tpe, hp
+
+class TestHyperopt(unittest.TestCase):
+    def test_find_min(self):
+        best = fmin(
+            fn=lambda x: x ** 2,
+            space=hp.uniform('x', -10, 10),
+            algo=tpe.suggest,
+            max_evals=1,
+        )
+        self.assertIn('x', best)


### PR DESCRIPTION
Latest release on pip is from January 2020. Installing using pip which uses pre-built whl is faster than building from source. We have no reason anymore to build it for source.

Added a test to prevent regression.