### PR TITLE
Remove keras-rcnn package.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,8 +61,6 @@ RUN apt-get install -y libfreetype6-dev && \
     pip install git+git://github.com/Lasagne/Lasagne.git && \
     pip install keras && \
     pip install keras-rl && \
-    #keras-rcnn
-    pip install git+https://github.com/broadinstitute/keras-rcnn && \
     pip install flake8 && \
     #neon
     cd /usr/local/src && \


### PR DESCRIPTION
Unmaintained (last updated in 2017) and only works with TensorFlow 1.13. For that reason, this package is effectively broken in our environment.

BUG=152539178