### PR TITLE
Remove pyflux package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -224,7 +224,6 @@ RUN pip install mpld3 && \
     pip install descartes && \
     pip install geojson && \
     pip install pysal && \
-    pip install pyflux && \
     pip install terminalplot && \
     pip install raccoon && \
     pip install pydicom && \


### PR DESCRIPTION
This package is NOT compatible with Python 3.7. We are in the process of upgrading to Python 3.7: b/142337634

This package hasn't been updated for 2 years and the author said it is abandoned:

> Note From Author : I am currently working on other projects as of now, so have paused updates for this library for the immediate future. If you'd like to help move the library forward by contributing, then do get in touch! I am planning to review at end of year and update the library as required (new version requirements, etc).

-- https://github.com/RJT1990/pyflux

BUG=152539178