### PR TITLE
Remove pyeconometrics package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -155,8 +155,6 @@ RUN pip install scipy && \
     pip install datashader && \
     # Boruta (python implementation)
     pip install Boruta && \
-    cd /usr/local/src && git clone git://github.com/nicolashennetier/pyeconometrics.git && \
-    cd pyeconometrics && python setup.py install && \
     apt-get install -y graphviz && pip install graphviz && \
     # Pandoc is a dependency of deap
     apt-get install -y pandoc && \


### PR DESCRIPTION
Unmaintained (last change in 2018), 7 GitHub stars. No usage.

BUG=152539178