### PR TITLE
Remove rf_perm_feat_import package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -179,7 +179,6 @@ RUN pip install mpld3 && \
     pip install nibabel && \
     pip install pronouncing && \
     pip install markovify && \
-    pip install rf_perm_feat_import && \
     pip install imgaug && \
     pip install preprocessing && \
     pip install Baker && \


### PR DESCRIPTION
Unmaintained (last change in 2017), 11 GitHub stars. No usage. It is only a single simple function. Our users can use utility scripts for that.

BUG=152539178