### PR TITLE
Set imagemagick policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,9 @@ ENV PROJ_LIB=/opt/conda/share/proj
 # Install conda packages not available on pip.
 # When using pip in a conda environment, conda commands should be ran first and then
 # the remaining pip commands: https://www.anaconda.com/using-pip-in-a-conda-environment/
-RUN conda install -c conda-forge matplotlib basemap cartopy python-igraph && \
+RUN conda install -c conda-forge matplotlib basemap cartopy python-igraph imagemagick && \
     conda install -c h2oai h2o && \
     conda install -c pytorch pytorch torchvision torchaudio cpuonly && \
-    conda install -c conda-forge/label/cf202003 imagemagick && \
     conda install -c anaconda pysal && \
     /tmp/clean-layer.sh
 
@@ -466,6 +465,8 @@ ADD patches/kaggle_web_client.py /root/.local/lib/python3.6/site-packages/kaggle
 ADD patches/kaggle_datasets.py /root/.local/lib/python3.6/site-packages/kaggle_datasets.py
 ADD patches/log.py /root/.local/lib/python3.6/site-packages/log.py
 ADD patches/sitecustomize.py /root/.local/lib/python3.6/site-packages/sitecustomize.py
+# Override default imagemagick policies
+ADD patches/imagemagick-policy.xml /etc/ImageMagick-6/policy.xml
 
 # TensorBoard Jupyter extension. Should be replaced with TensorBoard's provided magic once we have
 # worker tunneling support in place.

--- a/patches/imagemagick-policy.xml
+++ b/patches/imagemagick-policy.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+  <!ELEMENT policymap (policy)+>
+  <!ATTLIST policymap xmlns CDATA #FIXED ''>
+  <!ELEMENT policy EMPTY>
+  <!ATTLIST policy xmlns CDATA #FIXED '' domain NMTOKEN #REQUIRED
+    name NMTOKEN #IMPLIED pattern CDATA #IMPLIED rights NMTOKEN #IMPLIED
+    stealth NMTOKEN #IMPLIED value CDATA #IMPLIED>
+]>
+<policymap></policymap> 


### PR DESCRIPTION
- Install `imagemagick` from the conda-forge channel to always pick latest (currently the same version than `conda-forge/label/cf202003`.
- Permissive policy to allow reading all file types which prevent errors like `wand.exceptions.PolicyError: not authorized `/input/tests/data/test.pdf' @ error/constitute.c/ReadImage/412`.

Based on @vimota work in #731 
