### PR TITLE
Install pysal from conda-forge

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,9 @@ ENV PROJ_LIB=/opt/conda/share/proj
 # Install conda packages not available on pip.
 # When using pip in a conda environment, conda commands should be ran first and then
 # the remaining pip commands: https://www.anaconda.com/using-pip-in-a-conda-environment/
-RUN conda install -c conda-forge matplotlib basemap cartopy python-igraph imagemagick && \
+RUN conda install -c conda-forge matplotlib basemap cartopy python-igraph imagemagick pysal && \
     conda install -c h2oai h2o && \
     conda install -c pytorch pytorch torchvision torchaudio cpuonly && \
-    conda install -c anaconda pysal && \
     /tmp/clean-layer.sh
 
 # The anaconda base image includes outdated versions of these packages. Update them to include the latest version.

--- a/tests/test_pysal.py
+++ b/tests/test_pysal.py
@@ -1,0 +1,8 @@
+import unittest
+
+from pysal.weights import lat2W
+
+class TestPysal(unittest.TestCase):
+    def test_distance_band(self):
+        w = lat2W(4,4)
+        self.assertEqual(16, w.n)


### PR DESCRIPTION
Also added a test.

anaconda and conda-forge have the same version of pysal. Better to use a minimal # of channels because dependencies for a package are also installed from that channel in priority.