### PR TITLE
Add back scikit-image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,7 @@ RUN apt-get install -y libfreetype6-dev && \
     vader_lexicon verbnet webtext word2vec_sample wordnet wordnet_ic words ycoe && \
     # Stop-words
     pip install stop-words && \
+    pip install scikit-image && \
     /tmp/clean-layer.sh
 
 RUN pip install ibis-framework && \


### PR DESCRIPTION
This is a NoOp since this package is already part of the base image. 

However, we prefer to list it here explicitly. We also already have smoke test for this package.

Accidentally removed in #765, I meant to remove the `--upgrade` flag but I removed the full line instead.