### PR TITLE
Upgrade jaxlib

### DIFF
--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -76,7 +76,7 @@ ENV JAX_CUDA_VERSION=cuda$CUDA_MAJOR_VERSION$CUDA_MINOR_VERSION
 ENV JAX_PLATFORM=linux_x86_64
 ENV JAX_BASE_URL="https://storage.googleapis.com/jax-releases"
 
-RUN  pip install --upgrade $JAX_BASE_URL/$JAX_CUDA_VERSION/jaxlib-0.1.41-$JAX_PYTHON_VERSION-none-$JAX_PLATFORM.whl && \
+RUN  pip install --upgrade $JAX_BASE_URL/$JAX_CUDA_VERSION/jaxlib-0.1.43-$JAX_PYTHON_VERSION-none-$JAX_PLATFORM.whl && \
      pip install --upgrade jax
 
 # Reinstall packages with a separate version for GPU support.


### PR DESCRIPTION
Fixes error: `ValueError: jaxlib is version 0.1.41, but this version of jax requires version 0.1.43.`