### PR TITLE
Delete old tagged images from Jenkins GPU worker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,13 @@ pipeline {
       steps {
         sh '''#!/bin/bash
           set -exo pipefail
-          docker image prune -f # remove previously built image to prevent disk from filling up
+          # Remove images (dangling or not) created more than 120h (5 days ago) to prevent disk from filling up.
+          docker image prune --all --force --filter "until=120h"
+          # Remove any dangling images (no tags).
+          # All builds for the same branch uses the same tag. This means a subsequent build for the same branch
+          # will untag the previously built image which is safe to do. Builds for a single branch are performed
+          # serially.
+          docker image prune -f
           ./build --gpu --base-image-tag ${STAGING_TAG} | ts
           ./push --gpu ${PRETEST_TAG}
         '''


### PR DESCRIPTION
CPU Jenkins workers are ephemeral meaning they are recreated between each build.
GPU Jenkins workers are not, the GCP Jenkins plugin doesn't support GPU VMs well.

Every 2-3 weeks, the GPU builds would start failing because the disk has filled up.

We were already deleting dangling images (untagged). However, we were never deleting the old images with a tag (non-dangling). This meant that we kept the images from the last build for a given branch on the worker until the disk filled up causing failures. 

The fix was to manually SSH to the GPU worker and run `docker system prune -a -f` when it happened when a build failure cause by the GPU worker disk filling occured.

With this PR, we won't have build anymore failing for this reason and we won't need to perform that manual SSH step.

BUG=129682568