### PR TITLE
Downgrade libpixman to 0.34 to circumvent known bug in 0.38

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ ENV PROJ_LIB=/opt/conda/share/proj
 RUN conda install -c conda-forge matplotlib basemap cartopy python-igraph imagemagick pysal && \
     # b/142337634#comment22 pin required to avoid torchaudio downgrade.
     conda install -c pytorch pytorch torchvision "torchaudio>=0.4.0" cpuonly && \
+	conda install -c conda-forge --no-deps pixman==0.34 && \
     /tmp/clean-layer.sh
 
 # The anaconda base image includes outdated versions of these packages. Update them to include the latest version.

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,9 @@ ENV PROJ_LIB=/opt/conda/share/proj
 RUN conda install -c conda-forge matplotlib basemap cartopy python-igraph imagemagick pysal && \
     # b/142337634#comment22 pin required to avoid torchaudio downgrade.
     conda install -c pytorch pytorch torchvision "torchaudio>=0.4.0" cpuonly && \
-	conda install -c conda-forge --no-deps pixman==0.34 && \
+    # pixman 0.38.0 has a known issue causing issues with packages such as pycairo & openslide.
+    # See: https://gitlab.freedesktop.org/pixman/pixman/commit/8256c235d9b3854d039242356905eca854a890ba
+    conda install -c conda-forge --no-deps pixman==0.34 && \
     /tmp/clean-layer.sh
 
 # The anaconda base image includes outdated versions of these packages. Update them to include the latest version.


### PR DESCRIPTION
The container has an installation of libpixman 0.38.0, installed through the conda-forge. This version has a known bug (https://gitlab.freedesktop.org/pixman/pixman/commit/8256c235d9b3854d039242356905eca854a890ba), which can cause issues in any package using libcairo, such as pycairo and openslide, resulting in invalid images. This pull request downgrades the package to 0.34, which is a stable version also included in Ubuntu 18.04. 