### PR TITLE
Restrict which images are being pruned

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -491,6 +491,8 @@ ARG BUILD_DATE=unknown
 LABEL git-commit=$GIT_COMMIT
 LABEL build-date=$BUILD_DATE
 LABEL tensorflow-version=$TENSORFLOW_VERSION
+# Used in the Jenkins `Docker GPU Build` step to restrict the images being pruned.
+LABEL kaggle-image=python
 
 # Correlate current release with the git hash inside the kernel editor by running `!cat /etc/git_commit`.
 RUN echo "$GIT_COMMIT" > /etc/git_commit && echo "$BUILD_DATE" > /etc/build_date

--- a/Dockerfile
+++ b/Dockerfile
@@ -492,7 +492,7 @@ LABEL git-commit=$GIT_COMMIT
 LABEL build-date=$BUILD_DATE
 LABEL tensorflow-version=$TENSORFLOW_VERSION
 # Used in the Jenkins `Docker GPU Build` step to restrict the images being pruned.
-LABEL kaggle-image=python
+LABEL kaggle-lang=python
 
 # Correlate current release with the git hash inside the kernel editor by running `!cat /etc/git_commit`.
 RUN echo "$GIT_COMMIT" > /etc/git_commit && echo "$BUILD_DATE" > /etc/build_date

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
         sh '''#!/bin/bash
           set -exo pipefail
           # Remove images (dangling or not) created more than 120h (5 days ago) to prevent disk from filling up.
-          docker image prune --all --force --filter "until=120h" --filter "label=kaggle-image=python"
+          docker image prune --all --force --filter "until=120h" --filter "label=kaggle-lang=python"
           # Remove any dangling images (no tags).
           # All builds for the same branch uses the same tag. This means a subsequent build for the same branch
           # will untag the previously built image which is safe to do. Builds for a single branch are performed

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
         sh '''#!/bin/bash
           set -exo pipefail
           # Remove images (dangling or not) created more than 120h (5 days ago) to prevent disk from filling up.
-          docker image prune --all --force --filter "until=120h"
+          docker image prune --all --force --filter "until=120h" --filter "label=kaggle-image=python"
           # Remove any dangling images (no tags).
           # All builds for the same branch uses the same tag. This means a subsequent build for the same branch
           # will untag the previously built image which is safe to do. Builds for a single branch are performed


### PR DESCRIPTION
The `nvidia/cuda` and `gcr.io/kaggle-images/python-tensorflow-whl` are rarely updated. This means their creation time is very likely > 5 days. Every build, these images are pruned and then redownloaded. This adds several minutes to the build step.

Note: An image inherits the `LABEL`s from its parent image.

Next:
- Add the `kaggle-lang=r` LABEL to the `rcran` image
- Update the Jenkinsfile in `rstats` to delete images with LABEL `kaggle-lang=r`.

BUG=129682568