### PR TITLE
Added fix for libpixman 0.38 bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -449,6 +449,8 @@ RUN pip install --upgrade dask && \
     sed -i "s/^.*Matplotlib is building the font cache using fc-list.*$/# Warning removed by Kaggle/g" /opt/conda/lib/python3.7/site-packages/matplotlib/font_manager.py && \
     # Make matplotlib output in Jupyter notebooks display correctly
     mkdir -p /etc/ipython/ && echo "c = get_config(); c.IPKernelApp.matplotlib = 'inline'" > /etc/ipython/ipython_config.py && \
+    # Temporary patch for broken libpixman 0.38 in conda-forge, symlink to system libpixman 0.34 untile conda package gets updated to 0.38.5 or higher.
+    ln -sf /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.34.0 /opt/conda/lib/libpixman-1.so.0.38.0 && \
     /tmp/clean-layer.sh
 
 # gcloud SDK https://cloud.google.com/sdk/docs/quickstart-debian-ubuntu


### PR DESCRIPTION
The previous solution caused an inconsistent condo environment. Now I propose to symlink the system library into the condo environment to work around the bug in libpixman 0.38. This prevents inconsistency. Libcairo, which is the only package which directly depends on libpixman also works perfectly fine with pixman 0.34.