### PR TITLE
Add timeout for build/test steps to avoid holding up workers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,6 +21,9 @@ pipeline {
 
   stages {
     stage('Docker CPU Build') {
+      options {
+        timeout(time: 90, unit: 'MINUTES')
+      }
       steps {
         sh '''#!/bin/bash
           set -exo pipefail
@@ -32,6 +35,9 @@ pipeline {
     }
 
     stage('Test CPU Image') {
+      options {
+        timeout(time: 5, unit: 'MINUTES')
+      }
       steps {
         sh '''#!/bin/bash
           set -exo pipefail
@@ -62,6 +68,9 @@ pipeline {
       // TODO(rosbo) don't set `nvidia` as the default runtime and use the
       // `--runtime=nvidia` flag for the `docker run` command when GPU support is needed.
       agent { label 'ephemeral-linux-gpu' }
+      options {
+        timeout(time: 45, unit: 'MINUTES')
+      }
       steps {
         sh '''#!/bin/bash
           set -exo pipefail
@@ -80,6 +89,9 @@ pipeline {
 
     stage('Test GPU Image') {
       agent { label 'ephemeral-linux-gpu' }
+      options {
+        timeout(time: 20, unit: 'MINUTES')
+      }
       steps {
         sh '''#!/bin/bash
           set -exo pipefail


### PR DESCRIPTION
We had issues we a test hanging which held up indefinitely one of our GPU worker and had to be killed manually. This is to prevent this from happening.