### PR TITLE
Revert "Install tensorflow-gcs-config from the python-tensorflow-whl"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_TAG=latest
 ARG TENSORFLOW_VERSION=2.1.0
 
-FROM gcr.io/kaggle-images/python-tensorflow-whl:${TENSORFLOW_VERSION}-py37-3 as tensorflow_whl
+FROM gcr.io/kaggle-images/python-tensorflow-whl:${TENSORFLOW_VERSION}-py37-2 as tensorflow_whl
 FROM gcr.io/deeplearning-platform-release/base-cpu:${BASE_TAG}
 
 ADD clean-layer.sh  /tmp/clean-layer.sh
@@ -57,12 +57,6 @@ RUN pip install distributed==2.10.0 && \
 COPY --from=tensorflow_whl /tmp/tensorflow_cpu/*.whl /tmp/tensorflow_cpu/
 RUN pip install /tmp/tensorflow_cpu/tensorflow*.whl && \
     rm -rf /tmp/tensorflow_cpu && \
-    /tmp/clean-layer.sh
-
-# Install tensorflow-gcs-config from a pre-built wheel
-COPY --from=tensorflow_whl /tmp/tensorflow_gcs_config/*.whl /tmp/tensorflow_gcs_config/
-RUN pip install /tmp/tensorflow_gcs_config/tensorflow*.whl && \
-    rm -rf /tmp/tensorflow_gcs_config && \
     /tmp/clean-layer.sh
 
 RUN apt-get install -y libfreetype6-dev && \

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -5,4 +5,3 @@ class TestImport(unittest.TestCase):
     def test_basic(self):
         import bq_helper
         import cleverhans
-        import tensorflow_gcs_config


### PR DESCRIPTION
Reverts Kaggle/docker-python#788

Breaks tests against GPU build and probably doesn't work with a GPU.

Context: https://kaggle.slack.com/archives/CAHCTF54Z/p1588027289298700?thread_ts=1588026655.298500&cid=CAHCTF54Z