### PR TITLE
Add GLIBCXX_USE_CXX11_ABI=0 compiler define to TensorFlow CPU build

### DIFF
--- a/tensorflow-whl/Dockerfile
+++ b/tensorflow-whl/Dockerfile
@@ -73,7 +73,10 @@ RUN cd /usr/local/src && \
 # Create a tensorflow wheel for CPU
 RUN cd /usr/local/src/tensorflow && \
     cat /dev/null | ./configure && \
-    bazel build --config=opt --config=v2 //tensorflow/tools/pip_package:build_pip_package && \
+    bazel build --config=opt \
+                --config=v2 \
+                --cxxopt="-D_GLIBCXX_USE_CXX11_ABI=0" \
+                //tensorflow/tools/pip_package:build_pip_package && \
     bazel-bin/tensorflow/tools/pip_package/build_pip_package /tmp/tensorflow_cpu && \
     bazel clean
 


### PR DESCRIPTION
This matches the GPU build and allows the `tensorflow-gcs-config` wheel/package to work with both CPU and GPU versions of TF.

I've built tensorflow-whl locally with this change and built both the CPU and GPU docker-python images using the local tensorflow-whl image. All tests pass against both the CPU and GPU images.

http://b/152051681