### PR TITLE
Updated Dockerfile and added test for haskell-stack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,7 +115,7 @@ RUN apt-get install -y libfreetype6-dev && \
 RUN pip install ibis-framework && \
     pip install mxnet && \
     pip install gluonnlp && \
-    pip install gluoncv && \    
+    pip install gluoncv && \
     /tmp/clean-layer.sh
 
 # scikit-learn dependencies
@@ -430,6 +430,8 @@ RUN pip install flashtext && \
     pip install geopandas==0.6.3 && \
     pip install nnabla && \
     pip install vowpalwabbit && \
+    # install stack to build haskell projects
+    curl -sSL https://get.haskellstack.org/ | sh && \
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -430,8 +430,33 @@ RUN pip install flashtext && \
     pip install geopandas==0.6.3 && \
     pip install nnabla && \
     pip install vowpalwabbit && \
-    # install stack to build haskell projects
-    curl -sSL https://get.haskellstack.org/ | sh && \
+    /tmp/clean-layer.sh
+
+# install and setup stack to build haskell projects
+RUN curl -sSL https://get.haskellstack.org/ | sh && \
+    stack setup && stack update && \
+    stack install aeson && \
+    stack install vector && \
+    stack install union-find && \
+    stack install bytestring && \
+    stack install mtl && \
+    stack install pqueue && \
+    stack install containers && \
+    stack install hspec && \
+    stack install cmdargs && \
+    stack install filepath && \
+    stack install extra && \
+    stack install directory && \
+    stack install hashtables && \
+    stack install fail && \
+    stack install sort && \
+    stack install deepseq && \
+    stack install pooled-io && \
+    stack install hashtables && \
+    stack install vector-instances && \
+    stack install hashable && \
+    stack install transformers && \
+    stack install pantry && \
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages

--- a/tests/test_stack.py
+++ b/tests/test_stack.py
@@ -1,0 +1,12 @@
+import unittest
+
+import subprocess as sp
+
+class TestStack(unittest.TestCase):
+    def test_stack(self):
+        try:
+            proc = sp.Popen(["stack", "--version"], stdout = sp.PIPE, stderr = sp.PIPE)
+            stdout, stderr = proc.communicate()
+            self.assertEqual(proc.returncode, 0)
+        except:
+            self.assertTrue(False)


### PR DESCRIPTION
I have updated the Dockerfile to install `stack`, a common tool for building Haskell projects and managing their dependencies. Stack ought to be in the Kaggle kernel because Haskell developers must otherwise either
  1. Enable internet from a notebook and download stack *each time* they run the notebook. Not only is this bothersome and redundant, but relying on the internet is unsafe
  2. Ship pre-compiled binaries with a dataset, which is unstable across different architectures

I then added a list of common stack packages, as well as some stack packages necessary for our own submission.

Thank you!