### PR TITLE
pip install papermill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -422,6 +422,8 @@ RUN pip install flashtext && \
     pip install geopandas==0.6.3 && \
     pip install nnabla && \
     pip install vowpalwabbit && \
+    # papermill can replace nbconvert for executing notebooks
+    pip install papermill && \
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages
@@ -486,9 +488,6 @@ RUN jupyter-nbextension disable nb_conda --py --sys-prefix && \
     jupyter-serverextension disable nb_conda --py --sys-prefix && \
     jupyter-nbextension disable nbpresent --py --sys-prefix && \
     jupyter-serverextension disable nbpresent --py --sys-prefix
-
-# Install papermill so it can replace nbconvert as a method to execute notebooks.
-RUN pip install papermill
 
 # Set backend for matplotlib
 ENV MPLBACKEND "agg"

--- a/Dockerfile
+++ b/Dockerfile
@@ -487,6 +487,9 @@ RUN jupyter-nbextension disable nb_conda --py --sys-prefix && \
     jupyter-nbextension disable nbpresent --py --sys-prefix && \
     jupyter-serverextension disable nbpresent --py --sys-prefix
 
+# Install papermill so it can replace nbconvert as a method to execute notebooks.
+RUN pip install papermill
+
 # Set backend for matplotlib
 ENV MPLBACKEND "agg"
 

--- a/tests/data/notebook.ipynb
+++ b/tests/data/notebook.ipynb
@@ -11,6 +11,7 @@
     }
   ],
   "metadata":{
+    "kernelspec":{"language":"python","display_name":"Python 3","name":"python3"},
     "language_info":{
        "codemirror_mode":{
           "name":"ipython",

--- a/tests/test_papermill.py
+++ b/tests/test_papermill.py
@@ -1,0 +1,14 @@
+import unittest
+
+import subprocess
+
+class TestPapermill(unittest.TestCase):
+    def test_papermill(self):
+        result = subprocess.run([
+            'papermill',
+            '/input/tests/data/notebook.ipynb',
+            '-',
+        ], stdout=subprocess.PIPE)
+
+        self.assertEqual(0, result.returncode)
+        self.assertTrue(b'999' in result.stdout)


### PR DESCRIPTION
papermill provides a bunch of nice features for executing notebooks, including ones not provided by nbconvert.

Some key features we want:
* dump cell output to logs
* stop on cell error, but still include cell output up to the errored cell