### PR TITLE
Pin base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG BASE_TAG=latest
+# b/157908450 set to latest once numba 0.49.x fixes performance regression for datashader.
+ARG BASE_TAG=m46
 ARG TENSORFLOW_VERSION=2.2.0
 
 FROM gcr.io/kaggle-images/python-tensorflow-whl:${TENSORFLOW_VERSION}-py37-2 as tensorflow_whl


### PR DESCRIPTION
A new base image was released on May 28th. This new image includes numba
0.49.1 and llvmlite 0.32.0. Unfortunately, numba >= 0.49.0 has a
performance regression and packages such as datashader downgrades
it. llvmlite can't be downgraded safely since it is a distutils
package.

Pinning the base image until the numba/llvmlite performance regression
is fixed.

BUG=157908450