### PR TITLE
Add Support for FastAI 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -373,6 +373,7 @@ RUN pip install bcolz && \
     pip install pyarrow && \
     pip install feather-format && \
     pip install fastai && \
+    pip install fastai2 && \
     pip install torchtext && \
     pip install allennlp && \
     # b/149359379 remove once allennlp 1.0 is released which won't cause a spacy downgrade.


### PR DESCRIPTION
Include both fastai and fastai2 so users can use either version of the library. This will allow old users to use the older library and new users to use the newer library (fastai2)