### PR TITLE
Unpin distributed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,7 @@ RUN conda config --add channels conda-forge && \
     /tmp/clean-layer.sh
 
 # The anaconda base image includes outdated versions of these packages. Update them to include the latest version.
-# b/150498764 distributed 2.11.0 fails at import while trying to reach out to 8.8.8.8 since the network is disabled in our hermetic tests.
-RUN pip install distributed==2.10.0 && \
+RUN pip install distributed && \
     pip install seaborn python-dateutil dask && \
     pip install pyyaml joblib pytagcloud husl geopy ml_metrics mne pyshp && \
     pip install pandas && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,7 @@ RUN conda config --add channels conda-forge && \
     /tmp/clean-layer.sh
 
 # The anaconda base image includes outdated versions of these packages. Update them to include the latest version.
-RUN pip install distributed && \
-    pip install seaborn python-dateutil dask && \
+RUN pip install seaborn python-dateutil dask && \
     pip install pyyaml joblib pytagcloud husl geopy ml_metrics mne pyshp && \
     pip install pandas && \
     # Install h2o from source.

--- a/test
+++ b/test
@@ -87,6 +87,10 @@ fi
 # By default, TensorFlow maps nearly all of the GPU memory visible to the process.
 # This is causing issue when other libraries are trying to run tests using a GPU.
 # See: https://www.tensorflow.org/guide/gpu#allowing_gpu_memory_growth
+#
+# Note about `--hostname localhost` (b/158137436)
+# hostname defaults to the container name which fails DNS name
+# resolution with --net=none (required to keep tests hermetic). See details in bug.
 docker run --rm -t --read-only --net=none \
     -e HOME=/tmp -e KAGGLE_DATA_PROXY_TOKEN=test-key \
     -e KAGGLE_USER_SECRETS_TOKEN_KEY=test-secrets-key \
@@ -94,8 +98,6 @@ docker run --rm -t --read-only --net=none \
     -e KAGGLE_DATA_PROXY_URL=http://127.0.0.1:8000 \
     -e KAGGLE_DATA_PROXY_PROJECT=test \
     -e TF_FORCE_GPU_ALLOW_GROWTH=true \
-    # b/158137436: hostname defaults to the container name which fails DNS name
-    # resolution with --net=none (required to keep tests hermetic). See details in bug.
     --hostname localhost \
     --shm-size=2g \
     -v $PWD:/input:ro -v /tmp/python-build/working:/working \

--- a/test
+++ b/test
@@ -94,6 +94,9 @@ docker run --rm -t --read-only --net=none \
     -e KAGGLE_DATA_PROXY_URL=http://127.0.0.1:8000 \
     -e KAGGLE_DATA_PROXY_PROJECT=test \
     -e TF_FORCE_GPU_ALLOW_GROWTH=true \
+    # b/158137436: hostname defaults to the container name which fails DNS name
+    # resolution with --net=none (required to keep tests hermetic). See details in bug.
+    --hostname localhost \
     --shm-size=2g \
     -v $PWD:/input:ro -v /tmp/python-build/working:/working \
     -v /tmp/python-build/tmp:/tmp -v /tmp/python-build/devshm:/dev/shm \


### PR DESCRIPTION
* Remove `distributed` package downgrade.
* Fixed tests impacted by change in `distributed` which defaults to `hostname` instead of `localhost` since 2.11.0.

This is necessary for #595 (adding rapidsai) b/c it depends on `distributed` >= 2.12.0

BUG=158137436