### PR TITLE
Remove redundant opencv-python pip command.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -341,7 +341,6 @@ RUN pip install bcolz && \
     pip install nbformat && \
     pip install notebook==5.5.0 && \
     pip install olefile && \
-    pip install opencv-python && \
     pip install kornia && \
     pip install pandas_summary && \
     pip install pandocfilters && \


### PR DESCRIPTION
This package is already part of our base image and installed through Conda.

This command is a NoOp but confusing given that pip insn't used to install this package.

From the build logs: `Requirement already satisfied: opencv-python`

#825 