### PR TITLE
Add X-Kaggle-Authorization header to KaggleWebClient

### DIFF
--- a/patches/kaggle_web_client.py
+++ b/patches/kaggle_web_client.py
@@ -26,6 +26,7 @@ class KaggleWebClient:
         self.headers = {
             'Content-type': 'application/json',
             'Authorization': f'Bearer {self.jwt_token}',
+            'X-Kaggle-Authorization': f'Bearer {self.jwt_token}',
         }
 
     def make_post_request(self, data: dict, endpoint: str) -> dict:


### PR DESCRIPTION
In the future, we will use that custom header instead of a standard `Authorization` header which is used currently.

This is needed in order for us to work with IAP, which also expects an `Authorization` header, see [this doc](https://cloud.google.com/iap/docs/authentication-howto#authenticating_from_a_service_account).