### PR TITLE
Pin pytorch & torch* libs versions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN conda config --add channels conda-forge && \
     # 161473620#comment7 pin required to prevent resolver from picking pysal 1.x., pysal 2.2.x is also downloading data on import.
     conda install matplotlib basemap cartopy python-igraph imagemagick "pysal==2.1.0" && \
     # b/142337634#comment22 pin required to avoid torchaudio downgrade.
-    conda install "pytorch>=1.5.0" "torchvision>=0.6.0" "torchaudio>=0.5.0" cpuonly && \
+    # b/162357958##comment7 Upgrade once new versions of torch* libs are released for pytorch 1.6.
+    conda install "pytorch=1.5" "torchvision=0.6" "torchaudio=0.5" "torchtext=0.6" cpuonly && \
     /tmp/clean-layer.sh
 
 # The anaconda base image includes outdated versions of these packages. Update them to include the latest version.
@@ -373,7 +374,6 @@ RUN pip install bcolz && \
     pip install pyarrow && \
     pip install feather-format && \
     pip install fastai && \
-    pip install torchtext && \
     pip install allennlp && \
     python -m spacy download en && python -m spacy download en_core_web_lg && \
     apt-get install -y ffmpeg && \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get install -y ocl-icd-libopencl1 clinfo libboost-all-dev && \
 # However, because this image is based on the CPU image, this isn't possible but better
 # to put them at the top of this file to minize conflicts.
 RUN conda remove --force -y pytorch torchvision torchaudio cpuonly && \
-    conda install "pytorch>=1.5.0" "torchvision>=0.6.0" "torchaudio>=0.5.0" cudatoolkit=$CUDA_VERSION && \
+    conda install "pytorch=1.5" "torchvision=0.6" "torchaudio=0.5" "torchtext=0.6" cudatoolkit=$CUDA_VERSION && \
     /tmp/clean-layer.sh
 
 # Install LightGBM with GPU


### PR DESCRIPTION
pytorch 1.6 was released on 7/28. However, no new versions of torchaudio
have been released yet which is causing runtime errors:

```
OSError: /opt/conda/lib/python3.7/site-packages/torchaudio/_torchaudio.so: undefined symbol: _ZNK2at6Tensor6deviceEv
```

BUG=162357958