### PR TITLE
Update FastAI v1 to v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,6 +132,9 @@ RUN pip install ibis-framework && \
     pip install gluoncv && \
     /tmp/clean-layer.sh
 
+#update FastAI
+RUN pip install git+https://github.com/fastai/fastai
+
 # scikit-learn dependencies
 RUN pip install scipy && \
     pip install scikit-learn && \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -108,6 +108,9 @@ RUN pip install /tmp/tfa_gpu/tensorflow*.whl && \
     rm -rf /tmp/tfa_gpu/ && \
     /tmp/clean-layer.sh
 
+#Update FastAI
+RUN pip install git+https://github.com/fastai/fastai
+
 # Install GPU-only packages
 RUN pip install pycuda && \
     pip install cupy-cuda$CUDA_MAJOR_VERSION$CUDA_MINOR_VERSION && \


### PR DESCRIPTION
I'm currently in a competition that prohibits internet access through Kaggle notebooks, and I use FastAI in my modeling workflow, but Kaggle does not natively have FastAI v2 installed. FastAI v2 is a complete re-write of v1, and it would be very nice to be able to use it in Kaggle competitions. 