### PR TITLE
Store gsutil credentials in .boto file when storing gcloud credentials

### DIFF
--- a/tests/test_user_secrets.py
+++ b/tests/test_user_secrets.py
@@ -136,7 +136,7 @@ class TestUserSecrets(unittest.TestCase):
                           success=False)
 
     def test_set_gcloud_credentials_succeeds(self):
-        secret = '{"client_id":"gcloud","type":"authorized_user"}'
+        secret = '{"client_id":"gcloud","type":"authorized_user","refresh_token":"refresh_token"}'
         project = 'foo'
         account = 'bar'
 


### PR DESCRIPTION
The PR adds a call to `_write_gsutil_credentials_file` which would store the refresh token from gcloud credentials to `~/.boto` file used by `gsutil`. 

https://cloud.google.com/storage/docs/boto-gsutil

http://b/171747843