### PR TITLE
Pin fastai.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -374,7 +374,8 @@ RUN pip install bcolz && \
     pip install widgetsnbextension && \
     pip install pyarrow && \
     pip install feather-format && \
-    pip install fastai && \
+    # b/172491515: Unpin after upgrading to torch 1.7
+    pip install fastai==2.0.19 && \
     pip install allennlp && \
     python -m spacy download en && python -m spacy download en_core_web_lg && \
     apt-get install -y ffmpeg && \


### PR DESCRIPTION
fastai 2.1.x uses torch 1.7. Unfortunately, we can't upgrade to torch
1.7 yet. We need to wait until all the libraries depending on torch are
supported 1.7.

http://b/172468280