### PR TITLE
Remove dask xgboost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -229,7 +229,6 @@ RUN pip install mpld3 && \
     pip install geoplot && \
     pip install eli5 && \
     pip install implicit && \
-    pip install dask-ml[xgboost] && \
     pip install kaggle && \
     /tmp/clean-layer.sh
 


### PR DESCRIPTION
Fixes #911.

xgboost was downgraded from 1.x to 0.90 causing pain for XGBoost users (see #911).

This package only works with xgboost <= 0.90: https://github.com/dask/dask-xgboost/blob/master/requirements.txt#L1

The dask-xgboost package has very low usage (~100 over the last 90 days) and only ~100 stars on GitHub.

BUG=175051617