### PR TITLE
Replace (deprecated) theano with (maintained) theano-pymc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN apt-get install -y libfreetype6-dev && \
     pip install keras && \
     pip install keras-tuner && \
     pip install flake8 && \
-    pip install Theano && \
+    pip install theano-pymc && \
     pip install python-Levenshtein && \
     pip install hep_ml && \
     pip install chainer && \


### PR DESCRIPTION
As per https://github.com/Theano/Theano

> `MILA will stop developing Theano <https://groups.google.com/d/msg/theano-users/7Poq8BZutbY/rNCIfvAEAwAJ>`_.
>
>The PyMC developers are continuing Theano development in a `fork <https://github.com/pymc-devs/theano-pymc>`_.