### PR TITLE
Pin nnabla to 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -400,7 +400,8 @@ RUN pip install flashtext && \
     pip install dlib && \
     pip install kaggle-environments && \
     pip install geopandas && \
-    pip install nnabla && \
+    # b/175638062 remove pin once we update to cuDNN 8.x
+    pip install nnabla==1.13.0 && \
     pip install vowpalwabbit && \
     # papermill can replace nbconvert for executing notebooks
     pip install papermill && \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -103,7 +103,8 @@ RUN pip install /tmp/tfa_gpu/tensorflow*.whl && \
 RUN pip install pycuda && \
     pip install cupy-cuda$CUDA_MAJOR_VERSION$CUDA_MINOR_VERSION && \
     pip install pynvrtc && \
-    pip install nnabla-ext-cuda$CUDA_MAJOR_VERSION$CUDA_MINOR_VERSION && \
+    # b/175638062 remove pin once we update to cuDNN 8.x
+    pip install nnabla-ext-cuda$CUDA_MAJOR_VERSION$CUDA_MINOR_VERSION==1.13.0 && \
     /tmp/clean-layer.sh
 
 # Re-add TensorBoard Jupyter extension patch


### PR DESCRIPTION
The latest version (1.14) only works with cuDNN 8.x. However, we are
using 7.x. I filed a bug to look into upgrading cuDNN.

For now, pinning to 1.13 to make it work with cuDNN 7.x.

BUG=175636822