### PR TITLE
Pin umap-learn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -210,6 +210,8 @@ RUN pip install mpld3 && \
     pip install fbprophet && \
     pip install holoviews && \
     pip install geoviews && \
+    # b/177279594 umap-learn 0.5.0 is causing a llvmlite upgrade.
+    pip install umap-learn==0.4.6 && \
     pip install hypertools && \
     pip install py_stringsimjoin && \
     pip install mlens && \


### PR DESCRIPTION
`umap-learn` 0.5.0 (released on 1/11/2021, today) is causing a llvmlite upgrade.

This library should never be updated because it is a distutils project and cannot be cleanly reinstalled. Packages should be compatible with the version of llvmlite from the base image.