### PR TITLE
Upgrade papermill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -407,7 +407,7 @@ RUN pip install flashtext && \
     pip install nnabla==1.13.0 && \
     pip install vowpalwabbit && \
     # papermill can replace nbconvert for executing notebooks
-    pip install papermill && \
+    pip install --upgrade papermill && \
     pip install cloud-tpu-client && \
     pip install tensorflow-cloud && \
     pip install tensorflow-datasets && \


### PR DESCRIPTION
http://b/176254901

It wasn't upgraded in the latest `prerelease` image.

```
$ docker run -it gcr.io/kaggle-images/python:prerelease /bin/bash
root@322557b5cb60:/# papermill --version
2.1.0 from /opt/conda/lib/python3.7/site-packages/papermill/cli.py (3.7.6)
root@322557b5cb60:/# pip install --upgrade papermill
[...]
Successfully installed papermill-2.2.2
root@322557b5cb60:/# papermill --version
2.2.2 from /opt/conda/lib/python3.7/site-packages/papermill/cli.py (3.7.6)
```

