### PR TITLE
Add flask

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -413,6 +413,7 @@ RUN pip install flashtext && \
     pip install pytorch-lightning && \
     pip install datatable && \
     pip install sympy && \
+    pip install flask && \
     /tmp/clean-layer.sh
 
 # Tesseract and some associated utility packages

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,0 +1,10 @@
+import unittest
+
+from flask import Flask, request
+
+class TestFlask(unittest.TestCase):
+    def test_request(self):
+        app = Flask(__name__)
+        with app.test_request_context('/foo', method='POST'):
+            assert request.path == '/foo'
+            assert request.method == 'POST'


### PR DESCRIPTION
- Also added tests to prevent regression.

flask was removed from the base image we use:

```
rosbo@rosbo:~$ docker run -it --rm gcr.io/deeplearning-platform-release/base-cpu:m46 pip show flask
Name: Flask
Version: 1.1.2
Summary: A simple framework for building complex web applications.
Home-page: https://palletsprojects.com/p/flask/
Author: Armin Ronacher
Author-email: armin.ronacher@active-4.com
License: BSD-3-Clause
Location: /opt/conda/lib/python3.7/site-packages
Requires: Werkzeug, itsdangerous, click, Jinja2
Required-by:
rosbo@rosbo:~$ docker run -it --rm gcr.io/deeplearning-platform-release/base-cpu:m61 pip show flask
WARNING: Package(s) not found: flask
```