### PR TITLE
Remove warning from lightGBM test.

### DIFF
--- a/tests/test_lightgbm.py
+++ b/tests/test_lightgbm.py
@@ -21,6 +21,7 @@ class TestLightgbm(unittest.TestCase):
             'feature_fraction': 0.9,
             'bagging_fraction': 0.8,
             'bagging_freq': 5,
+            'force_row_wise': True,
             'verbose': 0
         }
 
@@ -46,6 +47,7 @@ class TestLightgbm(unittest.TestCase):
             'feature_fraction': 0.9,
             'bagging_fraction': 0.8,
             'bagging_freq': 5,
+            'force_row_wise': True,
             'verbose': 1,
             'device': 'gpu'
         }


### PR DESCRIPTION
```
[LightGBM] [Warning] Auto-choosing row-wise multi-threading, the overhead of testing was 0.000252 seconds.
You can set `force_row_wise=true` to remove the overhead.
```