### PR TITLE
Avoid having to use sudo for running the tests.

### DIFF
--- a/test
+++ b/test
@@ -69,7 +69,8 @@ readonly ADDITONAL_OPTS
 readonly PATTERN
 
 set -x
-rm -rf /tmp/python-build
+docker run --rm --net=none -v /tmp/python-build:/tmp/python-build "$IMAGE_TAG" rm -rf /tmp/python-build/*
+
 docker rm jupyter_test || true
 mkdir -p /tmp/python-build/tmp
 mkdir -p /tmp/python-build/devshm


### PR DESCRIPTION
A test run creates files under the /tmp/python-build directory. The
owner of these files are the user assigned to your docker process.

Running `rm -rf /tmp/python-build` in the test script fails with:

```
rm: cannot remove '/tmp/python-build/working/logs/train_log/events.out.tfevents.1614297217.localhost': Permission denied
...
```

Because your user don't have the permissions to delete these files.

Updating the `test` script to delete these files inside the a docker
container to circumvent this problem.