### PR TITLE
Install openssh-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list &
     # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#build-lightgbm
     apt-get install -y build-essential unzip cmake && \
     apt-get install -y libboost-dev libboost-program-options-dev libboost-system-dev libboost-thread-dev libboost-math-dev libboost-test-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev && \
+    # b/182601974: ssh client was removed from the base image but is required for packages such as stable-baselines.
+    apt-get install -y openssh-client && \
     pip install --upgrade pip && \
     /tmp/clean-layer.sh
 


### PR DESCRIPTION
In #967, I upgraded the base image from `m61` to `m64`.

The new  `m64` base image doesn't include a SSH client anymore.

This was causing issues with a learn course relying on `stable-baselines`. This package isn't included in our base image but is installed at runtime.

http://b/182601974