### PR TITLE
Fix catalyst test.

### DIFF
--- a/tests/test_catalyst.py
+++ b/tests/test_catalyst.py
@@ -141,10 +141,10 @@ class TestCatalyst(unittest.TestCase):
             logdir=logdir,
             num_epochs=num_epochs,
             verbose=False,
-            callbacks=[CheckpointCallback(save_n_best=3)]
+            callbacks=[CheckpointCallback(save_n_best=3, use_runner_logdir=True)]
         )
         
-        with open('./logs/checkpoints/_metrics.json') as f:
+        with open('./logs/_metrics.json') as f:
             metrics = json.load(f)
-            self.assertTrue(metrics['train.3']['loss'] < metrics['train.1']['loss'])
-            self.assertTrue(metrics['best']['loss'] < 0.35)
+            self.assertTrue(metrics['train.3']['valid']['loss'] < metrics['train.1']['valid']['loss'])
+            self.assertTrue(metrics['best']['valid']['loss'] < 0.35)

--- a/tests/test_nnabla.py
+++ b/tests/test_nnabla.py
@@ -20,7 +20,7 @@ class TestNNabla(unittest.TestCase):
         # forward
         c.forward()
 
-        self.assertAlmostEqual(c.d, a.d + b.d)
+        self.assertAlmostEqual(c.d, a.d + b.d, places=3)
 
     @gpu_test
     def test_cuda_ext(self):


### PR DESCRIPTION
Catalyst 21.x was released on 3/13. We were using 20.x. This release
included a breaking change for the CheckpointCallback class which
required updating our test.

Also fixed flaky nnabla test by relaxing the test assertions. 

http://b/182904788