### PR TITLE
Upgrade google-cloud-bigquery-storage to use 2.X

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -270,7 +270,8 @@ RUN pip install --upgrade cython && \
     pip install category_encoders && \
     # google-cloud-automl 2.0.0 introduced incompatible API changes, need to pin to 1.0.1
     pip install google-cloud-automl==1.0.1 && \
-    pip install google-cloud-bigquery==2.2.0 && \
+    pip install google-cloud-bigquery==2.* && \
+    pip install google-cloud-bigquery-storage==2.* && \
     pip install google-cloud-storage && \
     pip install google-cloud-translate==3.* && \
     pip install google-cloud-language==2.* && \

--- a/tests/test_biquery_storage.py
+++ b/tests/test_biquery_storage.py
@@ -1,0 +1,16 @@
+import subprocess
+
+def check_package_version(package):
+    output = subprocess.check_output("pip show " + package, shell=True)
+    for l in output.decode().split("\n"):
+        if l.startswith("Version:"):
+            return l.strip().split(" ")[1]
+
+# Make sure the google-cloud-bigquery and google-cloud-bigquery-storage are on the same major version
+class TestBigQueryStorage(unittest.TestCase):
+
+    def test_bq_and_storage_compatible(self):
+        bigquery_version = check_package_version("google-cloud-bigquery")
+        bq_storage_verstion = check_package_version("google-cloud-bigquery-storage")
+        self.assertEqual(bigquery_version[0], bq_storage_verstion[0])
+        


### PR DESCRIPTION
This is required due to the bigquery upgrade from 1.X to 2.X.