### PR TITLE
Uninstall google-cloud-bigquery-storage library.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -276,6 +276,8 @@ RUN pip install --upgrade cython && \
     pip install google-cloud-language==2.* && \
     pip install google-cloud-videointelligence==2.* && \
     pip install google-cloud-vision==2.* && \
+    # b/183041606#comment5: the Kaggle data proxy doesn't support these APIs. If the library is missing, it falls back to using a regular BigQuery query to fetch data.
+    pin uninstall -y google-cloud-bigquery-storage && \
     # After launch this should be installed from pip
     pip install git+https://github.com/googleapis/python-aiplatform.git@mb-release && \ 
     pip install ortools && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -277,7 +277,7 @@ RUN pip install --upgrade cython && \
     pip install google-cloud-videointelligence==2.* && \
     pip install google-cloud-vision==2.* && \
     # b/183041606#comment5: the Kaggle data proxy doesn't support these APIs. If the library is missing, it falls back to using a regular BigQuery query to fetch data.
-    pin uninstall -y google-cloud-bigquery-storage && \
+    pip uninstall -y google-cloud-bigquery-storage && \
     # After launch this should be installed from pip
     pip install git+https://github.com/googleapis/python-aiplatform.git@mb-release && \ 
     pip install ortools && \

--- a/tests/test_bigquery_storage.py
+++ b/tests/test_bigquery_storage.py
@@ -1,0 +1,9 @@
+import unittest
+
+class TestBigQueryStorage(unittest.TestCase):
+
+    def test_ensure_bq_storage_is_not_installed(self):
+        # b/183041606#comment5: Ensures bigquery_storage is not installed.
+        # bigquery falls back on using regular BQ queries which are supported by the BQ proxy.
+        with self.assertRaises(ImportError):
+            from google.cloud import bigquery_storage


### PR DESCRIPTION
This library is part of our base image (deeplearning-platform-release)
but not other libraries depend on it.

Removing this library ensures the bigquery library fall backs on using
regular BQ queries to fetch data.

The BigQuery storage APIs are not supported by our data proxy and we
don't monkey patch this client.

This change simply revert to the behavior we had with BQ 1.x libraries.

http://b/183041606