### PR TITLE
Pin pystan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -188,7 +188,8 @@ RUN pip install mpld3 && \
     pip install pyldavis && \
     pip install mlxtend && \
     pip install altair && \
-    pip install pystan && \
+    # b/183944405 pystan 3.x is not compatible with fbprophet.
+    pip install pystan==2.19.1.1 && \
     pip install ImageHash && \
     pip install ecos && \
     pip install CVXcanon && \


### PR DESCRIPTION
pystan 3.x released on March 25th, 2021 is not compatible with
fbprophet and causing a build failure.

http://b/183944405