### PR TITLE
Keep the pip version from the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list &
     apt-get install -y libboost-dev libboost-program-options-dev libboost-system-dev libboost-thread-dev libboost-math-dev libboost-test-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev && \
     # b/182601974: ssh client was removed from the base image but is required for packages such as stable-baselines.
     apt-get install -y openssh-client && \
-    pip install --upgrade pip && \
     /tmp/clean-layer.sh
 
 # Make sure the dynamic linker finds the right libstdc++

--- a/tensorflow-whl/Dockerfile
+++ b/tensorflow-whl/Dockerfile
@@ -50,8 +50,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ln -s /usr/local/cuda-$CUDA_MAJOR_VERSION.$CUDA_MINOR_VERSION /usr/local/cuda && \
     ln -s /usr/local/cuda/lib64/stubs/libcuda.so /usr/local/cuda/lib64/stubs/libcuda.so.1
 
-RUN pip install --upgrade pip
-
 # Use Bazelisk to ensure the proper bazel version is used.
 RUN cd /usr/local/src && \
     wget --no-verbose "https://github.com/bazelbuild/bazelisk/releases/download/v1.7.4/bazelisk-linux-amd64" && \


### PR DESCRIPTION
Currently latest == the one in m66 (i.e. NoOp).
Remove this to prevent unnecessary churn.