### PR TITLE
Pin nltk to 3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,8 @@ RUN pip install /tmp/tfa_cpu/tensorflow*.whl && \
 RUN apt-get install -y libfreetype6-dev && \
     apt-get install -y libglib2.0-0 libxext6 libsm6 libxrender1 libfontconfig1 --fix-missing && \
     pip install gensim && \
+    # b/184748065 remove pin to nltk once fix has been provided for the pytest production dependency.
+    pip install nltk==3.5 && \
     pip install textblob && \
     pip install wordcloud && \
     pip install xgboost && \


### PR DESCRIPTION
`nltk` version 3.6 released earlier today includes a production
dependency on pytest. They are working on a hotfix:
https://github.com/nltk/nltk/pull/2693.

Pinning to 3.5 until the new version is out.

http://b/184748065