### PR TITLE
Revert "Pin nltk to 3.5 (#988)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,6 @@ RUN pip install /tmp/tfa_cpu/tensorflow*.whl && \
 RUN apt-get install -y libfreetype6-dev && \
     apt-get install -y libglib2.0-0 libxext6 libsm6 libxrender1 libfontconfig1 --fix-missing && \
     pip install gensim && \
-    # b/184748065 remove pin to nltk once fix has been provided for the pytest production dependency.
-    pip install nltk==3.5 && \
     pip install textblob && \
     pip install wordcloud && \
     pip install xgboost && \


### PR DESCRIPTION
A new version of nltk with the hotfix was released an hour ago:
- https://pypi.org/project/nltk/#history
- https://github.com/nltk/nltk/pull/2693#issuecomment-815281396

This reverts commit bda8a17e6a232cab291536e753e03a3b9c965c95.