### PR TITLE
Tza ta ai

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -178,10 +178,7 @@ RUN pip install scipy && \
     pip install git+git://github.com/scikit-learn-contrib/py-earth.git@issue191 && \
     pip install essentia && \
     conda install -y pytorch torchvision torchaudio cpuonly -c pytorch && \
-    pip install --no-cache-dir torch-scatter && \
-    pip install --no-cache-dir torch-sparse && \
-    pip install --no-cache-dir torch-cluster && \
-    pip install --no-cache-dir torch-spline-conv && \
+    pip install --no-cache-dir torch-scatter torch-sparse torch-cluster torch-spline-conv && \
     pip install torch-geometric && \
     /tmp/clean-layer.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -181,8 +181,8 @@ RUN pip install scipy && \
     pip install --no-cache-dir torch-scatter && \
     pip install --no-cache-dir torch-sparse && \
     pip install --no-cache-dir torch-cluster && \
-    pip install --no-cache-dir torch-spline-conv  && \
-    pip install torch-geometric
+    pip install --no-cache-dir torch-spline-conv && \
+    pip install torch-geometric && \
     /tmp/clean-layer.sh
 
 # vtk with dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -178,6 +178,11 @@ RUN pip install scipy && \
     pip install git+git://github.com/scikit-learn-contrib/py-earth.git@issue191 && \
     pip install essentia && \
     conda install -y pytorch torchvision torchaudio cpuonly -c pytorch && \
+    pip install --no-cache-dir torch-scatter && \
+    pip install --no-cache-dir torch-sparse && \
+    pip install --no-cache-dir torch-cluster && \
+    pip install --no-cache-dir torch-spline-conv  && \
+    pip install torch-geometric
     /tmp/clean-layer.sh
 
 # vtk with dependencies

--- a/Python5.yml
+++ b/Python5.yml
@@ -1,0 +1,1 @@
+kaggle kernels pull nigrilh/notebookee4a1e0816

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -18,6 +18,8 @@ ENV CUDA_PKG_VERSION=10-0=$CUDA_VERSION-1
 LABEL com.nvidia.volumes.needed="nvidia_driver"
 LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
+# Use shell parameter extension to handle the case that CPATH is likely unset.
+ENV CPATH=/usr/local/cuda/include:${CPATH:+\:${CPATH}}
 # The stub is useful to us both for built-time linking and run-time linking, on CPU-only systems.
 # When intended to be used with actual GPUs, make sure to (besides providing access to the host
 # CUDA user libraries, either manually or through the use of nvidia-docker) exclude them. One

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -19,6 +19,7 @@ LABEL com.nvidia.volumes.needed="nvidia_driver"
 LABEL com.nvidia.cuda.version="${CUDA_VERSION}"
 ENV PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}
 # Use shell parameter extension to handle the case that CPATH is likely unset.
+# CPATH needs to be set for the torch-geometrics package: https://github.com/rusty1s/pytorch_geometric#installation
 ENV CPATH=/usr/local/cuda/include:${CPATH:+\:${CPATH}}
 # The stub is useful to us both for built-time linking and run-time linking, on CPU-only systems.
 # When intended to be used with actual GPUs, make sure to (besides providing access to the host
@@ -56,6 +57,9 @@ RUN pip uninstall -y tensorflow && \
     pip uninstall -y mxnet && \
     # b/126259508 --no-deps prevents numpy from being downgraded.
     pip install --no-deps mxnet-cu100 && \
+    pip uninstall torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric && \
+    pip install --no-cache-dir torch-scatter torch-sparse torch-cluster torch-spline-conv && \
+    pip install torch-geometric && \
     /tmp/clean-layer.sh
 
 # Install GPU-only packages

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -57,7 +57,7 @@ RUN pip uninstall -y tensorflow && \
     pip uninstall -y mxnet && \
     # b/126259508 --no-deps prevents numpy from being downgraded.
     pip install --no-deps mxnet-cu100 && \
-    pip uninstall torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric && \
+    pip uninstall -y torch-scatter torch-sparse torch-cluster torch-spline-conv torch-geometric && \
     pip install --no-cache-dir torch-scatter torch-sparse torch-cluster torch-spline-conv && \
     pip install torch-geometric && \
     /tmp/clean-layer.sh

--- a/tests/test_pytorch_geometric.py
+++ b/tests/test_pytorch_geometric.py
@@ -1,0 +1,114 @@
+import unittest
+
+import torch
+import torch_cluster
+import torch_geometric
+import torch_sparse
+import torch_scatter
+
+from torch_geometric.data import Data
+from torch_sparse import coalesce
+from torch_geometric.nn import SplineConv
+
+
+class TestTorchGeometric(unittest.TestCase):
+    def setUp(self):
+        self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+    def test_scatter(self):
+        src = torch.tensor([[2, 0, 1, 4, 3], [0, 2, 1, 3, 4]]).to(self.device)
+        index = torch.tensor([[4, 5, 4, 2, 3], [0, 0, 2, 2, 1]]).to(self.device)
+        out, argmax = torch_scatter.scatter_max(src, index, fill_value=0)
+        test_argmax = torch.LongTensor([[-1, -1,  3,  4,  0,  1],
+                                        [ 1,  4,  3, -1, -1, -1]]).to(self.device)
+        test_out = torch.LongTensor([[0, 0, 4, 3, 2, 0],
+                                     [2, 4, 3, 0, 0, 0]]).to(self.device)
+        self.assertTrue(torch.all(torch.eq(test_argmax, argmax)))
+        self.assertTrue(torch.all(torch.eq(test_out, out)))
+
+    def test_cluster(self):
+        x = torch.Tensor([[-1, -1], [-1, 1], [1, -1], [1, 1]]).to(self.device)
+        batch = torch.tensor([0, 0, 0, 0]).to(self.device)
+        edge_index = torch_cluster.knn_graph(x, k=2, batch=batch, loop=False).to(self.device)
+        test_edge_index = torch.LongTensor([[2, 1, 3, 0, 3, 0, 1, 2],
+                                            [0, 0, 1, 1, 2, 2, 3, 3]]).to(self.device)
+        edge_list = edge_index.tolist()
+        test_edge_list = test_edge_index.tolist()
+        del edge_index, test_edge_index
+        # need to transpose the edges to (ei, ej) format
+        edge_list = [(edge_list[0][i], edge_list[1][i]) for i in range(len(edge_list[0]))]
+        test_edge_list = [(test_edge_list[0][i], test_edge_list[1][i]) for i in range(len(test_edge_list[0]))]
+        self.assertCountEqual(edge_list, test_edge_list)
+
+    def test_sparse(self):
+        index = torch.tensor([[1, 0, 1, 0, 2, 1],
+                              [0, 1, 1, 1, 0, 0]]).to(self.device)
+        value = torch.Tensor([[1, 2], [2, 3], [3, 4], [4, 5], [5, 6], [6, 7]]).to(self.device)
+
+        index, value = torch_sparse.transpose(index, value, 3, 2)
+        test_index = torch.LongTensor([[0, 0, 1, 1],
+                                       [1, 2, 0, 1]]).to(self.device)
+        test_value = torch.Tensor([[7., 9.], [5., 6.], [6., 8.], [3., 4.]]).to(self.device)
+        self.assertTrue(torch.all(torch.eq(test_index, index)))
+        self.assertTrue(torch.all(torch.eq(test_value, value)))
+
+    def test_spline_conv(self):
+        in_channels, out_channels = (16, 32)
+        edge_index = torch.tensor([[0, 0, 0, 1, 2, 3], [1, 2, 3, 0, 0, 0]]).to(self.device)
+        num_nodes = edge_index.max().item() + 1
+        x = torch.randn((num_nodes, in_channels)).to(self.device)
+        pseudo = torch.rand((edge_index.size(1), 3)).to(self.device)
+
+        conv = SplineConv(in_channels, out_channels, dim=3, kernel_size=5).to(self.device)
+        self.assertEqual('SplineConv(16, 32)', conv.__repr__())
+        with torch_geometric.debug():
+            self.assertEqual((num_nodes, out_channels), conv(x, edge_index, pseudo).size())
+
+    def test_geometric(self):
+        x = torch.tensor([[1, 3, 5], [2, 4, 6]], dtype=torch.float).t().to(self.device)
+        edge_index = torch.tensor([[0, 0, 1, 1, 2], [1, 1, 0, 2, 1]]).to(self.device)
+        data = Data(x=x, edge_index=edge_index).to(torch.device('cpu'))
+
+        N = data.num_nodes
+
+        self.assertCountEqual(data.x.tolist(), x.tolist())
+        self.assertCountEqual(data['x'].tolist(), x.tolist())
+
+        self.assertEqual(['edge_index', 'x'], sorted(data.keys))
+        self.assertEqual(2, len(data))
+        self.assertIn('x', data)
+        self.assertIn('edge_index', data)
+        self.assertNotIn('pos', data)        
+        self.assertEqual(0, data.__cat_dim__('x', data.x))
+        self.assertEqual(-1, data.__cat_dim__('edge_index', data.edge_index))
+        self.assertEqual(0, data.__inc__('x', data.x))
+        self.assertEqual(data.num_nodes, data.__inc__('edge_index', data.edge_index))
+        data.contiguous()
+        self.assertTrue(data.x.is_contiguous())
+
+        data.edge_index, _ = coalesce(data.edge_index, None, N, N)
+        data = data.coalesce()
+        self.assertTrue(data.is_coalesced())
+
+        clone = data.clone()
+        self.assertNotEqual(clone, data)
+        self.assertEqual(len(clone), len(data))
+        self.assertCountEqual(clone.x.tolist(), data.x.tolist())
+        self.assertCountEqual(clone.edge_index.tolist(), data.edge_index.tolist())
+
+        data['x'] = x + 1
+        self.assertCountEqual(data.x.tolist(), (x + 1).tolist())
+
+        self.assertEqual('Data(edge_index=[2, 4], x=[3, 2])', data.__repr__())
+
+        dictionary = {'x': data.x, 'edge_index': data.edge_index}
+        data = Data.from_dict(dictionary)
+        self.assertEqual(['edge_index', 'x'], sorted(data.keys))
+
+        self.assertTrue(data.is_undirected())
+
+        self.assertEqual(3, data.num_nodes)
+        self.assertEqual(4, data.num_edges)
+        self.assertIsNone(data.num_faces)
+        self.assertEqual(2, data.num_node_features)
+        self.assertEqual(2, data.num_features)


### PR DESCRIPTION
{
  "nbformat": 4,
  "nbformat_minor": 0,
  "metadata": {
    "colab": {
      "name": "The %tensorflow_version magic",
      "provenance": [],
      "collapsed_sections": [],
      "include_colab_link": true
    },
    "kernelspec": {
      "display_name": "Python 3",
      "name": "python3"
    }
  },
  "cells": [
    {
      "cell_type": "markdown",
      "metadata": {
        "id": "view-in-github",
        "colab_type": "text"
      },
      "source": [
        "<a href=\"https://colab.research.google.com/github/Leeeooo19888/.github/blob/master/The_tensorflow_version_magic.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
      ]
    },
    {
      "cell_type": "markdown",
      "metadata": {
        "id": "nPDc8yQtVxk4"
      },
      "source": [
        "#TensorFlow versions in Colab"
      ]
    },
    {
      "cell_type": "markdown",
      "metadata": {
        "id": "N2y2uqx9GfA5"
      },
      "source": [
        "\n",
        "##Background\n",
        "Colab has two versions of TensorFlow pre-installed: a 2.x version and a 1.x version. Colab uses TensorFlow 2.x by default, though you can switch to 1.x by the method shown below.\n"
      ]
    },
    {
      "cell_type": "markdown",
      "metadata": {
        "id": "aR_btJrKGdw7"
      },
      "source": [
        "##Specifying the TensorFlow version\n",
        "\n",
        "Running `import tensorflow` will import the default version (currently 2.x). You can use 1.x by running a cell with the `tensorflow_version` magic **before** you run `import tensorflow`."
      ]
    },
    {
      "cell_type": "code",
      "metadata": {
        "colab": {
          "base_uri": "https://localhost:8080/",
          "height": 34
        },
        "id": "NeWVBhf1VxlH",
        "outputId": "71110d1a-35e7-4471-ae2c-557564d7ce17"
      },
      "source": [
        "%tensorflow_version 1.x"
      ],
      "execution_count": null,
      "outputs": [
        {
          "output_type": "stream",
          "text": [
            "TensorFlow 1.x selected.\n"
          ],
          "name": "stdout"
        }
      ]
    },
    {
      "cell_type": "markdown",
      "metadata": {
        "id": "8dSlimhOVxlQ"
      },
      "source": [
        "Once you have specified a version via this magic, you can run `import tensorflow` as normal and verify which version was imported as follows:"
      ]
    },
    {
      "cell_type": "code",
      "metadata": {
        "colab": {
          "base_uri": "https://localhost:8080/",
          "height": 34
        },
        "id": "-XbfkU7BeziQ",
        "outputId": "dd5fde23-75de-4e80-a51f-d7ce42ae31e7"
      },
      "source": [
        "import tensorflow\n",
        "print(tensorflow.__version__)"
      ],
      "execution_count": null,
      "outputs": [
        {
          "output_type": "stream",
          "text": [
            "1.15.2\n"
          ],
          "name": "stdout"
        }
      ]
    },
    {
      "cell_type": "markdown",
      "metadata": {
        "id": "uBIKyjpEVxlU"
      },
      "source": [
        "If you want to switch TensorFlow versions after import, you **will need to restart your runtime** with 'Runtime' -> 'Restart runtime...' and then specify the version before you import it again."
      ]
    },
    {
      "cell_type": "markdown",
      "metadata": {
        "id": "8UvRkm1JGUrk"
      },
      "source": [
        "## Avoid Using ``pip install`` with GPUs and TPUs\n",
        "\n",
        "We recommend against using ``pip install`` to specify a particular TensorFlow version for both GPU and TPU backends. Colab builds TensorFlow from source to ensure compatibility with our fleet of accelerators. Versions of TensorFlow fetched from PyPI by ``pip`` may suffer from performance problems or may not work at all."
      ]
    }
  ]
}