### PR TITLE
Unpin wand

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -443,7 +443,7 @@ RUN mkdir -p /root/.EasyOCR/model && \
 # Tesseract and some associated utility packages
 RUN apt-get install tesseract-ocr -y && \
     pip install pytesseract && \
-    pip install wand==0.5.3 && \
+    pip install wand && \
     pip install pdf2image && \
     pip install PyPDF && \
     pip install pyocr && \


### PR DESCRIPTION
Latest version of `wand` is compatible with latest version of tesseract