### PR TITLE
Adding pandarallel library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -427,6 +427,7 @@ RUN pip install flashtext && \
     pip install jax==0.2.12 jaxlib==0.1.64 && \
     # ipympl adds interactive widget support for matplotlib
     pip install ipympl==0.7.0 && \
+    pip install pandarallel && \
     /tmp/clean-layer.sh
 
 # Download base easyocr models.

--- a/tests/test_pandarralel.py
+++ b/tests/test_pandarralel.py
@@ -1,0 +1,11 @@
+import unittest
+
+import pandas as pd
+from pandarallel import pandarallel
+
+pandarallel.initialize()
+
+class TestPandarallel(unittest.TestCase):    
+    def test_pandarallel(self):
+        data = pd.read_csv("/input/tests/data/train.csv")
+        data['label_converted'] = data['label'].parallel_apply(lambda x: x+1)


### PR DESCRIPTION
Pandarallel allows to execute pandas apply method in parallel, which allows to do data preprocessing faster and easier. This is very helpful in kernel only competitions.

For more information, see:

https://github.com/nalepae/pandarallel