### PR TITLE
Fix spacy test.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -350,7 +350,7 @@ RUN pip install bleach && \
     pip install allennlp && \
     # https://b.corp.google.com/issues/184685619#comment9: 3.9.0 is causing a major performance degradation with spacy 2.3.5
     pip install importlib-metadata==3.4.0 && \
-    python -m spacy download en && python -m spacy download en_core_web_lg && \
+    python -m spacy download en_core_web_sm && python -m spacy download en_core_web_lg && \
     apt-get install -y ffmpeg && \
     /tmp/clean-layer.sh
 

--- a/tests/test_spacy.py
+++ b/tests/test_spacy.py
@@ -4,6 +4,6 @@ import spacy
 
 class TestSpacy(unittest.TestCase):
     def test_model(self):
-        nlp = spacy.load('en')
+        nlp = spacy.load('en_core_web_sm')
         doc = nlp('This is a sentence.')
         self.assertEqual(5, len(doc))


### PR DESCRIPTION
spacy has been upgraded to 3.x (fastai had a 2.x requirement but now
support 3.x which upgraded spacy.)

`en` model name shortcut is no longer available in spacy 3.x