### PR TITLE
Fix warning in openslide test

### DIFF
--- a/tests/test_openslide.py
+++ b/tests/test_openslide.py
@@ -4,6 +4,5 @@ from openslide import open_slide
 
 class TestOpenslide(unittest.TestCase):
     def test_read_tif(self):
-        slide = open_slide('/input/tests/data/test.tif')
-        
-        self.assertEqual(1, slide.level_count)
+        with open_slide('/input/tests/data/test.tif') as slide:
+            self.assertEqual(1, slide.level_count)


### PR DESCRIPTION
```
ResourceWarning: unclosed file <_io.BufferedReader name='/input/tests/data/test.tif'>
  testMethod()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```