### PR TITLE
Pin fastai to 2.2.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -346,7 +346,8 @@ RUN pip install bleach && \
     pip install widgetsnbextension && \
     pip install pyarrow && \
     pip install feather-format && \
-    pip install fastai && \
+    # fastai >= 2.3.1 upgrades pytorch/torchvision. upgrade of pytorch will be handled in b/181966788
+    pip install fastai==2.2.7 && \
     pip install allennlp && \
     # https://b.corp.google.com/issues/184685619#comment9: 3.9.0 is causing a major performance degradation with spacy 2.3.5
     pip install importlib-metadata==3.4.0 && \


### PR DESCRIPTION
fastai 2.3.1 upgrades torch and torchvision causing issues.

upgrading torch proved more difficult than I thought (unresolvable
conflicts atm). will handle the upgrade later in b/181966788

http://b/188429515