### PR TITLE
Pin tensorflow-cloud to 1.1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -412,9 +412,8 @@ RUN pip install flashtext && \
     pip install vowpalwabbit && \
     # papermill can replace nbconvert for executing notebooks
     pip install cloud-tpu-client && \
-    # b/188429515#comment7 tensorflow-transform 1.x is causing an upgrade to TensorFlow 2.5.
-    pip install tensorflow-transform==0.30.0 && \
-    pip install tensorflow-cloud && \
+    # b/188429515#comment7 tensorflow-cloud >= 0.1.14 installs tensorflow-transform which install apache-beam which downgrades the google.cloud library to 1.x.
+    pip install tensorflow-cloud==0.1.13 && \
     pip install tensorflow-datasets && \
     pip install pydub && \
     pip install pydegensac && \


### PR DESCRIPTION
Starting in 1.1.14, `tensorflow-cloud` requires `tensorflow-transform`
which requires `apache-beam[gcp]`. `apache-beam` downgrades the
`google.cloud` libraries to 1.x. However, we are using 2.x

http://b/188429515