### PR TITLE
Add the vaex library (includes a test)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -365,6 +365,7 @@ RUN pip install bleach && \
 
 RUN pip install flashtext && \
     pip install wandb && \
+    pip install vaex && \
     pip install marisa-trie && \
     pip install pyemd && \
     pip install pyupset && \

--- a/tests/test_vaex.py
+++ b/tests/test_vaex.py
@@ -1,0 +1,10 @@
+import unittest
+
+import vaex
+
+class TestVaex(unittest.TestCase):
+    def test_read_csv(self):
+        df = vaex.read_csv("/input/tests/data/train.csv")
+
+        self.assertEqual((100, 785), df.shape)
+        self.assertEqual(10, df['label'].nunique())


### PR DESCRIPTION
This PR adds the [vaex](https://github.com/vaexio/vaex) library to the docker image. 

Also related to https://github.com/Kaggle/docker-python/issues/928.