### PR TITLE
Upgrade to TensorFlow 2.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TAG=m73
-ARG TENSORFLOW_VERSION=2.4.1
+ARG TENSORFLOW_VERSION=2.5.0
 
 FROM gcr.io/deeplearning-platform-release/base-cpu:${BASE_TAG}
 
@@ -60,8 +60,8 @@ RUN pip install seaborn python-dateutil dask && \
     /tmp/clean-layer.sh
 
 RUN pip install tensorflow==${TENSORFLOW_VERSION} && \
-    pip install tensorflow-gcs-config==2.4.0 && \
-    pip install tensorflow-addons==0.12.1 && \
+    pip install tensorflow-gcs-config==${TENSORFLOW_VERSION} && \
+    pip install tensorflow-addons==0.13.0 && \
     /tmp/clean-layer.sh
 
 RUN apt-get install -y libfreetype6-dev && \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -83,7 +83,7 @@ RUN pip install jax==0.2.16 jaxlib==0.1.68+cuda$CUDA_MAJOR_VERSION$CUDA_MINOR_VE
 
 # Reinstall packages with a separate version for GPU support.
 RUN pip uninstall -y tensorflow && \
-    pip install tensorflow-gpu==2.4.1 && \
+    pip install tensorflow-gpu==2.5.0 && \
     pip uninstall -y mxnet && \
     pip install mxnet-cu$CUDA_MAJOR_VERSION$CUDA_MINOR_VERSION && \
     /tmp/clean-layer.sh


### PR DESCRIPTION
- Upgraded tensorflow-addons and tensorflow-gcs-config packages
(requires to get TF 2.5 support).
- Removed comment about `ktext` package. This packages hasn't been
updated since 2019 and won't be in the future.