### PR TITLE
Ensures tests are run against the previously built image.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,6 +43,7 @@ pipeline {
           set -exo pipefail
 
           date
+          docker pull gcr.io/kaggle-images/python:${PRETEST_TAG}
           ./test --image gcr.io/kaggle-images/python:${PRETEST_TAG}
         '''
       }
@@ -85,6 +86,7 @@ pipeline {
           set -exo pipefail
 
           date
+          docker pull gcr.io/kaggle-private-byod/python:${PRETEST_TAG}
           ./test --gpu --image gcr.io/kaggle-private-byod/python:${PRETEST_TAG}
         '''
       }


### PR DESCRIPTION
In some rare cases, image is built on GPU worker 1 and tests are run on GPU worker 2. If GPU worker 2 has already an image with the `${branch_name}-pretest` tag from a previous build, then, the tests are ran against the wrong image.

Solution: Always pull before running the tests. If the image on the worker is already the latest, this is a NoOp. If it is an image from a previous build, it will pull the latest image from GCR.
