### PR TITLE
Adds hdbscan and pyclustering libraries. Fixes #1055

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,8 @@ RUN apt-get install -y libfreetype6-dev && \
     pip install textblob && \
     pip install wordcloud && \
     pip install xgboost && \
+    pip install hdbscan && \
+    pip install pyclustering && \
     # Pinned to match GPU version. Update version together.
     pip install lightgbm==3.2.1 && \
     pip install pydot && \


### PR DESCRIPTION
Adds the [hdbscan](https://hdbscan.readthedocs.io/en/latest/) library, which is suitable for fast clustering on large datasets, and the [pyclustering](https://pyclustering.github.io/docs/0.8.2/html/index.html) library, which enables Xmeans clustering and other methods not found in scikit-learn