### PR TITLE
Install blas & mkl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,8 +42,9 @@ RUN conda config --add channels conda-forge && \
     conda config --add channels nvidia && \
     conda config --add channels rapidsai && \
     # ^ rapidsai is the highest priority channel, default lowest, conda-forge 2nd lowest.
+    conda install mkl blas && \
     # b/161473620#comment7 pin required to prevent resolver from picking pysal 1.x., pysal 2.2.x is also downloading data on import.
-    conda install cartopy=0.19 imagemagick=7.0 pyproj==3.1.0 pysal==2.1.0 mkl blas && \
+    conda install cartopy=0.19 imagemagick=7.0 pyproj==3.1.0 pysal==2.1.0 && \
     /tmp/clean-layer.sh
 
 RUN pip install torch==1.7.1+cpu torchvision==0.8.2+cpu torchaudio==0.7.2 torchtext==0.8.1 -f https://download.pytorch.org/whl/torch_stable.html && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN conda config --add channels conda-forge && \
     conda config --add channels rapidsai && \
     # ^ rapidsai is the highest priority channel, default lowest, conda-forge 2nd lowest.
     # b/161473620#comment7 pin required to prevent resolver from picking pysal 1.x., pysal 2.2.x is also downloading data on import.
-    conda install cartopy=0.19 imagemagick=7.0 pyproj==3.1.0 pysal==2.1.0 && \
+    conda install cartopy=0.19 imagemagick=7.0 pyproj==3.1.0 pysal==2.1.0 mkl blas && \
     /tmp/clean-layer.sh
 
 RUN pip install torch==1.7.1+cpu torchvision==0.8.2+cpu torchaudio==0.7.2 torchtext==0.8.1 -f https://download.pytorch.org/whl/torch_stable.html && \

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -12,5 +12,5 @@ class TestNumpy(unittest.TestCase):
     # Numpy must be linked to the MKL. (Occasionally, a third-party package will muck up the installation
     # and numpy will be reinstalled with an OpenBLAS backing.)
     def test_mkl(self):
-        # This will throw an exception if the MKL is not linked correctly.
-        get_info("blas_mkl")
+        # This will throw an exception if the MKL is not linked correctly or return an empty dict.
+        self.assertTrue(get_info("blas_mkl"))


### PR DESCRIPTION
These are necessary for the TPU pytorch XLA.
They also provide a significant perforance boost.

They used to be automatically included when we were installing torch
from conda but they are not now that we install torch from pip.

I added a test to prevent regression.

http://b/195414519