### PR TITLE
Fix TLS error when upgrading nvidia packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,8 @@ ADD clean-layer.sh  /tmp/clean-layer.sh
 ADD patches/nbconvert-extensions.tpl /opt/kaggle/nbconvert-extensions.tpl
 ADD patches/template_conf.json /opt/kaggle/conf.json
 
-# This is necessary for apt to access HTTPS sources
-RUN apt-get update && \
-    apt-get install apt-transport-https && \
-    /tmp/clean-layer.sh
-
-    # Use a fixed apt-get repo to stop intermittent failures due to flaky httpredir connections,
-    # as described by Lionel Chan at http://stackoverflow.com/a/37426929/5881346
+# Use a fixed apt-get repo to stop intermittent failures due to flaky httpredir connections,
+# as described by Lionel Chan at http://stackoverflow.com/a/37426929/5881346
 RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list && \
     apt-get update && \
     # Needed by vowpalwabbit & lightGBM (GPU build).
@@ -30,7 +25,7 @@ RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list &
     /tmp/clean-layer.sh
 
 # Make sure the dynamic linker finds the right libstdc++
-ENV LD_LIBRARY_PATH=/opt/conda/lib
+ENV LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/opt/conda/lib
 # b/128333086: Set PROJ_LIB to points to the proj4 cartographic library.
 ENV PROJ_LIB=/opt/conda/share/proj
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,8 @@ RUN pip install tensorflow==${TENSORFLOW_VERSION} && \
 
 RUN apt-get install -y libfreetype6-dev && \
     apt-get install -y libglib2.0-0 libxext6 libsm6 libxrender1 libfontconfig1 --fix-missing && \
-    pip install gensim && \
+    # b/198300835 kornia 4.1.0 is not compatible with our version of numpy.
+    pip install gensim==4.0.1 && \
     pip install textblob && \
     pip install wordcloud && \
     pip install xgboost && \
@@ -299,7 +300,8 @@ RUN pip install bleach && \
     pip install notebook && \
     pip install papermill && \
     pip install olefile && \
-    pip install kornia && \
+    # b/198300835 kornia 0.5.10 is not compatible with our version of numpy.
+    pip install kornia==0.5.8 && \
     pip install pandas_summary && \
     pip install pandocfilters && \
     pip install pexpect && \

--- a/gpu.Dockerfile
+++ b/gpu.Dockerfile
@@ -9,8 +9,6 @@ ADD clean-layer.sh  /tmp/clean-layer.sh
 COPY --from=nvidia /etc/apt/sources.list.d/cuda.list /etc/apt/sources.list.d/
 COPY --from=nvidia /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/
 COPY --from=nvidia /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/cuda.gpg
-# See b/142337634#comment28
-RUN sed -i 's/deb https:\/\/developer.download.nvidia.com/deb http:\/\/developer.download.nvidia.com/' /etc/apt/sources.list.d/*.list
 
 ENV CUDA_MAJOR_VERSION=11
 ENV CUDA_MINOR_VERSION=0


### PR DESCRIPTION
We used to download the nvidia packages using apt over http. However
this is not supported anymore causing a build failure.

After much trial and error, I found that `apt` was not properly using the system certificate because of a broken
LD_LIBRARY_PATH. See the bug below for full context.

Additionally, new versions of `gensim` and `kornia` were released on August 29th and 30th respectively which are incompatible with our version of numpy. I pinned the version of these packages.

http://b/197989446