### PR TITLE
Add hf/datasets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -378,6 +378,7 @@ RUN pip install flashtext && \
     pip install qgrid && \
     pip install bqplot && \
     pip install earthengine-api && \
+    pip install datasets && \
     pip install transformers && \
     pip install dlib && \
     pip install kaggle-environments && \

--- a/tests/test_hf_datasets.py
+++ b/tests/test_hf_datasets.py
@@ -1,0 +1,10 @@
+import unittest
+
+from datasets import Dataset
+
+
+class TestHfDatasets(unittest.TestCase):
+    def test_adam_w(self):
+        dset = Dataset.from_dict({"col1": ["a", "b", "c"], "col2": [1, 2, 3]})
+        self.assertEqual(dset.num_rows, 3)
+        self.assertEqual(dset.num_columns, 2)

--- a/tests/test_hf_datasets.py
+++ b/tests/test_hf_datasets.py
@@ -4,7 +4,7 @@ from datasets import Dataset
 
 
 class TestHfDatasets(unittest.TestCase):
-    def test_adam_w(self):
+    def test_create_dataset_from_dict(self):
         dset = Dataset.from_dict({"col1": ["a", "b", "c"], "col2": [1, 2, 3]})
         self.assertEqual(dset.num_rows, 3)
         self.assertEqual(dset.num_columns, 2)


### PR DESCRIPTION
This PR adds hf/datasets to kaggle kernels.
hf/datasets is the largest hub of ML datasets and has almost 10k stars on GitHub.

Link to the package repo: https://github.com/huggingface/datasets.