### PR TITLE
add GH Action build

### DIFF
--- a/.github/workflows/ci-dockers.yml
+++ b/.github/workflows/ci-dockers.yml
@@ -1,0 +1,28 @@
+name: CI build Docker
+# https://www.docker.com/blog/first-docker-github-action-is-here
+# https://github.com/docker/build-push-action
+# see: https://help.github.com/en/actions/reference/events-that-trigger-workflows
+on: # Trigger the workflow on push or pull request, but only for the master branch
+  push:
+    branches: [main]
+  pull_request: {}
+
+jobs:
+
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+      matrix:
+        files: ["Dockerfile", "gpu.Dockerfile", "dev.Dockerfile"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build Docker
+        # publish master/release
+        uses: docker/build-push-action@v2
+        with:
+          file: ${{ matrix.files }}
+          push: false
+        timeout-minutes: 90


### PR DESCRIPTION
add CI building images as GH actions that are accessible to contributors
at this moment the Jenkins `continuous-integration/jenkins/pr-head` is private to contributors who do not see results and it is quite hard to fix failing PR on their own...