### PR TITLE
Remove unnecessary packages

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -25,11 +25,9 @@ RUN pip uninstall -y horovod && \
 # as described by Lionel Chan at http://stackoverflow.com/a/37426929/5881346
 RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list && \
     apt-get update && \
-    # Needed by vowpalwabbit & lightGBM (GPU build).
-    # https://github.com/VowpalWabbit/vowpal_wabbit/wiki/Python#installing
+    # Needed by lightGBM (GPU build)
     # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#build-lightgbm
-    apt-get install -y build-essential unzip cmake && \
-    apt-get install -y libboost-dev libboost-program-options-dev libboost-system-dev libboost-thread-dev libboost-math-dev libboost-test-dev libboost-python-dev libboost-filesystem-dev zlib1g-dev && \
+    apt-get install -y build-essential unzip cmake libboost-dev libboost-system-dev libboost-filesystem-dev && \
     # b/182601974: ssh client was removed from the base image but is required for packages such as stable-baselines.
     apt-get install -y openssh-client && \
     /tmp/clean-layer.sh
@@ -64,8 +62,8 @@ RUN pip install torch==1.7.1+cpu torchvision==0.8.2+cpu torchaudio==0.7.2 torcht
 # Install LightGBM
 ENV LIGHTGBM_VERSION=3.2.1
 {{ if eq .Accelerator "gpu" }}
-# Install OpenCL & libboost (required by LightGBM GPU version)
-RUN apt-get install -y ocl-icd-libopencl1 clinfo libboost-all-dev && \
+# Install OpenCL (required by LightGBM GPU version)
+RUN apt-get install -y ocl-icd-libopencl1 clinfo && \
     mkdir -p /etc/OpenCL/vendors && \
     echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd && \
     cd /usr/local/src && \


### PR DESCRIPTION
We don't build `vowpal_wabbit` from source and LightGBM needs only a subset of libboost-dev librairies.
