### PR TITLE
Add /opt/bin to GPU image PATH env variable

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -14,6 +14,8 @@ FROM gcr.io/kaggle-images/python-torch-whl:${GPU_BASE_IMAGE_NAME}-${BASE_IMAGE_T
 FROM ${BASE_IMAGE_REPO}/${GPU_BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}
 ENV CUDA_MAJOR_VERSION=11
 ENV CUDA_MINOR_VERSION=0
+# NVIDIA binaries from the host are mounted to /opt/bin.
+ENV PATH=/opt/bin:${PATH}
 {{ else }}
 FROM ${BASE_IMAGE_REPO}/${CPU_BASE_IMAGE_NAME}:${BASE_IMAGE_TAG}
 {{ end }}


### PR DESCRIPTION
NVIDIA binaries from the host are mounted to /opt/bin.

This is how `nvidia-smi` is made accessible inside the user session docker container. See attached bugs for additional context.

b/202852505

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
-->

Fixes #\<issue_number>
