### PR TITLE
Install matrixprofile from git to solve protobuf downgrade issue.

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -449,6 +449,8 @@ RUN pip install flashtext && \
     pip install https://github.com/hbasria/ggpy/archive/0.11.5.zip && \
     pip install cesium && \
     pip install rgf_python && \
+    # b/205704651 remove install cmd for matrixprofile after version > 1.1.10 is released.
+    pip install git+git://github.com/matrix-profile-foundation/matrixprofile.git@6bea7d4445284dbd9700a097974ef6d4613fbca7 && \
     pip install tsfresh && \
     # b/204442455 unpin once tsfresh is compatible with latest version of statsmodels.
     pip install statsmodels==0.12.2 && \


### PR DESCRIPTION
The matrixprofile in pip downgrades protobuf because the release whl has
the wrong requirements.txt file.

http://b/205704651