### PR TITLE
Install py4j

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -239,6 +239,8 @@ RUN pip install mpld3 && \
     pip install haversine && \
     pip install toolz cytoolz && \
     pip install plotly && \
+    # b/206631257: hyperopt requires py4j >= 0.2.6 requires py4j but doesn't list it as a dependency. Remove once hyperopt properly list it.
+    pip install py4j && \
     pip install hyperopt && \
     pip install fitter && \
     pip install langid && \


### PR DESCRIPTION
The latest version of `hyperopt` (0.2.6) requires `py4j` but doesn't list it
as a requirement.

This caused our tests to start failing.

`py4j` is a package to access Java objects.

http://b/206631257

## What does this PR do?

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.

If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
-->

Fixes #\<issue_number>
