### PR TITLE
Pin osmx to 1.1.1

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -460,7 +460,8 @@ RUN pip install flashtext && \
     pip install plotly_express && \
     pip install albumentations && \
     pip install catalyst && \
-    pip install osmnx && \
+    # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want. 
+    pip install osmnx==1.1.1 && \
     apt-get -y install libspatialindex-dev && \
     pip install pytorch-ignite && \
     pip install qgrid && \


### PR DESCRIPTION
Prevent upgrade to numpy 1.21.x.

The latest version of osmx (1.1.2) requires numpy >= 1.21: https://github.com/gboeing/osmnx/blob/6f9236f20a81416bf34186a811a8ebb76afa0dc8/requirements.txt#L4

http://b/206990323