### PR TITLE
Fix LD_LIBRARY_PATH for the CPU image.

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -574,5 +574,7 @@ LABEL kaggle-lang=python
 # Correlate current release with the git hash inside the kernel editor by running `!cat /etc/git_commit`.
 RUN echo "$GIT_COMMIT" > /etc/git_commit && echo "$BUILD_DATE" > /etc/build_date
 
+{{ if eq .Accelerator "gpu" }}
 # Remove the CUDA stubs.
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH_NO_STUBS"
+{{ end }}


### PR DESCRIPTION
Removing the CUDA stubs from the `LD_LIBRARY_PATH` should only be done for the GPU build.
`LD_LIBRARY_PATH_NO_STUBS` is not defined for the CPU build causing the LD_LIBRARY_PATH to be set to `""`.

http://b/207036238