### PR TITLE
Remove pynvml pin

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -127,8 +127,7 @@ RUN pip install mxnet && \
 # Install GPU-only packages
 RUN pip install pycuda && \
     pip install pynvrtc && \
-    # b/190622765 latest version is causing issue. nnabla fixed it in https://github.com/sony/nnabla/issues/892, waiting for new release before we can remove this pin.
-    pip install pynvml==8.0.4 && \
+    pip install pynvml && \
     pip install nnabla-ext-cuda$CUDA_MAJOR_VERSION$CUDA_MINOR_VERSION && \
     /tmp/clean-layer.sh
 {{ end }}


### PR DESCRIPTION
Latest version of `nnabla` is now compatible with latest version of `pynvml`