### PR TITLE
Remove explicit dependency on py4j

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -240,8 +240,6 @@ RUN pip install mpld3 && \
     pip install haversine && \
     pip install toolz cytoolz && \
     pip install plotly && \
-    # b/206631257: hyperopt requires py4j >= 0.2.6 requires py4j but doesn't list it as a dependency. Remove once hyperopt properly list it.
-    pip install py4j && \
     pip install hyperopt && \
     pip install fitter && \
     pip install langid && \


### PR DESCRIPTION
The `hyperopt` package now lists `py4j` as a dependency: https://github.com/hyperopt/hyperopt/blob/dfdb48d1dd9917fad347316a7818a9dcd160f200/setup.py#L51

See: b/206631257