### PR TITLE
Install implicit from conda

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -77,6 +77,15 @@ RUN conda install cudf=21.10 cuml=21.10 cudatoolkit=$CUDA_MAJOR_VERSION.$CUDA_MI
     /tmp/clean-layer.sh
 {{ end }}
 
+# Install implicit
+{{ if eq .Accelerator "gpu" }}
+RUN conda install implicit implicit-proc=*=gpu && \
+    /tmp/clean-layer.sh
+{{ else }}
+RUN conda install implicit && \
+    /tmp/clean-layer.sh
+{{ end}}
+
 # Install PyTorch
 {{ if eq .Accelerator "gpu" }}
 COPY --from=torch_whl /tmp/whl/*.whl /tmp/torch/
@@ -297,7 +306,6 @@ RUN pip install mpld3 && \
     pip install pymongo && \
     pip install geoplot && \
     pip install eli5 && \
-    pip install implicit && \
     pip install kaggle && \
     /tmp/clean-layer.sh
 

--- a/tests/test_implicit.py
+++ b/tests/test_implicit.py
@@ -1,0 +1,32 @@
+import unittest
+
+import numpy as np
+
+from implicit.als import AlternatingLeastSquares
+from scipy.sparse import csr_matrix
+
+
+class TestImplicit(unittest.TestCase):
+    def test_model(self):
+        raw = [
+            [0.0, 2.0, 1.5, 1.33333333, 1.25, 1.2, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 2.0, 1.5, 1.33333333, 1.25, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333, 1.25, 1.2],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333, 1.25],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5, 1.33333333],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 1.5],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0],
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+        ]
+        counts = csr_matrix(raw, dtype=np.float64)
+
+        model = AlternatingLeastSquares(factors=3)
+        model.fit(counts, show_progress=False)
+        rows, cols = model.item_factors, model.user_factors
+
+        assert not np.isnan(np.sum(cols))
+        assert not np.isnan(np.sum(rows))


### PR DESCRIPTION
- Installing from pip installs from source. Faster to install binary
from conda
- Fixes build issues since we are building the GPU image with stubs.
- Added a smoke test

http://b/211665716