### PR TITLE
Fix pip install from git and pin opencv

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -192,6 +192,8 @@ RUN apt-get install -y libfreetype6-dev && \
 
 RUN pip install ibis-framework && \
     pip install gluonnlp && \
+    # b/212703016 4.5.4.62 segfault with readtext.
+    pip install opencv-contrib-python==4.5.4.60 opencv-python==4.5.4.60 && \
     pip install gluoncv && \
     /tmp/clean-layer.sh
 
@@ -215,7 +217,7 @@ RUN pip install scipy && \
     apt-get install -y graphviz && pip install graphviz && \
     # Pandoc is a dependency of deap
     apt-get install -y pandoc && \
-    pip install git+git://github.com/scikit-learn-contrib/py-earth.git@issue191 && \
+    pip install git+https://github.com/scikit-learn-contrib/py-earth.git@issue191 && \
     pip install essentia && \
     /tmp/clean-layer.sh
 
@@ -455,7 +457,7 @@ RUN pip install flashtext && \
     pip install cesium && \
     pip install rgf_python && \
     # b/205704651 remove install cmd for matrixprofile after version > 1.1.10 is released.
-    pip install git+git://github.com/matrix-profile-foundation/matrixprofile.git@6bea7d4445284dbd9700a097974ef6d4613fbca7 && \
+    pip install git+https://github.com/matrix-profile-foundation/matrixprofile.git@6bea7d4445284dbd9700a097974ef6d4613fbca7 && \
     pip install tsfresh && \
     # b/204442455 unpin once tsfresh is compatible with latest version of statsmodels.
     pip install statsmodels==0.12.2 && \


### PR DESCRIPTION
As of yesterday, GitHub no longer supports unauthenticated git:// calls: https://news.ycombinator.com/item?id=29891656

Pinning version of opencv to avoid segfault. See: https://github.com/JaidedAI/EasyOCR/issues/630

http://b/212703016 (opencv segfault)
http://b/214044576 (GitHub issue)