### PR TITLE
Pin torchmetrics.

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -483,7 +483,8 @@ RUN pip install flashtext && \
     pip install vowpalwabbit && \
     pip install pydub && \
     pip install pydegensac && \
-    pip install torchmetrics && \
+    # b/215182966 torchmetrics 0.7.0 is causing an issue with pytorch-lightning.
+    pip install torchmetrics==0.6.2 && \
     pip install pytorch-lightning && \
     pip install datatable && \
     pip install sympy && \


### PR DESCRIPTION
`torchmetrics` 0.7.0 released yesterday (Jan 17th 2022) is causing an issue with pytorch_lightning: https://github.com/PyTorchLightning/pytorch-lightning/issues/11524