### PR TITLE
pin fury==0.7.1 to fix breakage

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -315,6 +315,7 @@ RUN pip install mpld3 && \
     pip install folium && \
     pip install scikit-plot && \
     # dipy requires the optional fury dependency for visualizations.
+    # b/217761018 pinned fury to fix test
     pip install fury==0.7.1 dipy && \
     pip install plotnine && \
     pip install scikit-surprise && \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -315,7 +315,7 @@ RUN pip install mpld3 && \
     pip install folium && \
     pip install scikit-plot && \
     # dipy requires the optional fury dependency for visualizations.
-    pip install fury dipy && \
+    pip install fury==0.7.1 dipy && \
     pip install plotnine && \
     pip install scikit-surprise && \
     pip install pymongo && \


### PR DESCRIPTION
Version 0.8.0 causes test_dipy to break with ImportError: cannot import name 'vtk' from 'fury.window' 

http://b/217761018