### PR TITLE
Adding scikit-learn-intelex package

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -212,6 +212,8 @@ RUN pip install ibis-framework && \
 
 RUN pip install scipy && \
     pip install scikit-learn && \
+    # Scikit-learn accelerated library for x86 
+    pip install scikit-learn-intelex && \
     # HDF5 support
     pip install h5py && \
     pip install biopython && \


### PR DESCRIPTION
This PR integrates accelerated x86 scikit-learn library that brings noticeable performance improvements for scikit-learn as well as set of AutoML frameworks(AutoGluon, autoscikit-learn, PyCaret, etc. ) that are using scikit-learn internally. 

Link to github project - https://github.com/intel/scikit-learn-intelex .  Accelerations achieved through use of oneDAL library  - https://github.com/oneapi-src/oneDAL

There is set of users/notebooks that already use accelerations - https://www.kaggle.com/search?q=scikit-learn-intelex 

Based on demonstrated results across notebooks we see that on Kaggle instances 2x-40x speedups can be achieved. This leads to productivity, results, CO2 reduction improvements.  
