### PR TITLE
Remove pin of fury

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -314,9 +314,7 @@ RUN pip install mpld3 && \
     pip install lightfm && \
     pip install folium && \
     pip install scikit-plot && \
-    # dipy requires the optional fury dependency for visualizations.
-    # b/217761018 pinned fury to fix test
-    pip install fury==0.7.1 dipy && \
+    pip install fury dipy && \
     pip install plotnine && \
     pip install scikit-surprise && \
     pip install pymongo && \


### PR DESCRIPTION
Latest version of dipy (1.5.0) released last week requires the latest
version of fury (0.8.0).

http://b/224623471