### PR TITLE
Pin Jinja2

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -302,6 +302,8 @@ RUN pip install mpld3 && \
     pip install sklearn-pandas && \
     pip install stemming && \
     pip install fbprophet && \
+    # b/227040197 Remove pin once panel (dependency of holoviews & geoviews) supports Jinja2 >= 3.1
+    pip install Jinja2==3.0.3 && \
     pip install holoviews && \
     pip install geoviews && \
     pip install hypertools && \


### PR DESCRIPTION
`holoviews` and `geoviews` uses `panel` which doesn't work with Jinja2 >= 3.1. 

The issue has been fixed now: https://github.com/holoviz/panel/issues/3257

Pinning to unblock our build. Will remove the pin once new version of panel is released.

http://b/227040197