### PR TITLE
Install latest version of nbconvert to fix Jinja issue.

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -389,7 +389,6 @@ RUN pip install bleach && \
     pip install ipywidgets && \
     pip install isoweek && \
     pip install jedi && \
-    pip install Jinja2 && \
     pip install jsonschema && \
     pip install jupyter-client && \
     pip install jupyter-console && \
@@ -397,7 +396,7 @@ RUN pip install bleach && \
     pip install MarkupSafe && \
     pip install mistune && \
     # b/227194111 install latest version of nbconvert until the base image includes nbconvert >= 6.4.5
-    pip install --upgrade nbconvert && \
+    pip install --upgrade nbconvert Jinja2 && \
     pip install nbformat && \
     pip install notebook && \
     pip install papermill && \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -396,7 +396,8 @@ RUN pip install bleach && \
     pip install jupyter-core && \
     pip install MarkupSafe && \
     pip install mistune && \
-    pip install nbconvert && \
+    # b/227194111 install latest version of nbconvert until the base image includes nbconvert >= 6.4.5
+    pip install --upgrade nbconvert && \
     pip install nbformat && \
     pip install notebook && \
     pip install papermill && \

--- a/tests/test_jupyter_nbconvert.py
+++ b/tests/test_jupyter_nbconvert.py
@@ -3,12 +3,28 @@ import unittest
 import subprocess
 
 class TestJupyterNbconvert(unittest.TestCase):
-    def test_nbconvert(self):
+    def test_nbconvert_to_notebook(self):
         result = subprocess.run([
             'jupyter',
             'nbconvert',
             '--to',
             'notebook',
+            '--template',
+            '/opt/kaggle/nbconvert-extensions.tpl',
+            '--execute',
+            '--stdout',
+            '/input/tests/data/notebook.ipynb',
+        ], stdout=subprocess.PIPE)
+
+        self.assertEqual(0, result.returncode)
+        self.assertTrue(b'999' in result.stdout)
+
+    def test_nbconvert_to_html(self):
+        result = subprocess.run([
+            'jupyter',
+            'nbconvert',
+            '--to',
+            'html',
             '--template',
             '/opt/kaggle/nbconvert-extensions.tpl',
             '--execute',


### PR DESCRIPTION
The latest version of Jinja changed the import for `Markup`.

The import was fixed in the latest version of `nbconvert`: https://github.com/jupyter/nbconvert/issues/1736

We include the version of `nbconvert` from the DLVM base image which is
released every ~2 weeks. However, the `nbconvert` fix was released only
6 hours ago.

Temporarily install thel latest version of `nbconvert`.

Add a test to prevent regression.

http://b/227194111