### PR TITLE
Fix NVIDIA GPG key issue.

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -54,6 +54,10 @@ RUN pip uninstall -y horovod && \
 # Use a fixed apt-get repo to stop intermittent failures due to flaky httpredir connections,
 # as described by Lionel Chan at http://stackoverflow.com/a/37426929/5881346
 RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list && \
+    # b/230864778: Temporarily swap the NVIDIA GPG key. Remove once new base image with new GPG key is released.
+    rm /etc/apt/sources.list.d/cuda.list && \
+    apt-key del 7fa2af80 && \
+    apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub && \
     apt-get update && \
     # Needed by lightGBM (GPU build)
     # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#build-lightgbm


### PR DESCRIPTION
Context: https://github.com/NVIDIA/nvidia-docker/issues/1631

The next `deeplearning-platform-release/tf2-gpu.2-6` should remove the
need for this workaround.

http://b/230864778