### PR TITLE
Fix access to libtpu

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
         }
         stage('tensorflow TPU') {
           options {
-            timeout(time: 360, unit: 'MINUTES')
+            timeout(time: 240, unit: 'MINUTES')
           }
           steps {
             sh '''#!/bin/bash
@@ -176,6 +176,14 @@ pipeline {
               steps {
                 sh '''#!/bin/bash
                   set -exo pipefail
+
+                  # Login to docker to get access to gcr.io/cloud-tpu-v2-images/libtpu
+                  # SA: jenkins-test@kaggle-playground-170215.iam.gserviceaccount.com
+                  # To grant access to a SA, start a TPU VM with that SA once.
+                  METADATA=http://metadata.google.internal/computeMetadata/v1
+                  SVC_ACCT=$METADATA/instance/service-accounts/default
+                  ACCESS_TOKEN=$(/usr/bin/curl -s -H 'Metadata-Flavor: Google' $SVC_ACCT/token | cut -d'"' -f 4)
+                  docker login --username oauth2accesstoken --password $ACCESS_TOKEN https://gcr.io
 
                   ./tpu/build | ts
                   ./push --tpu ${PRETEST_TAG}


### PR DESCRIPTION
The jenkins SA did not have access to pull the libtpu docker image needed for the TPU VM build.
I started a TPU VM with that SA to grant it access, and added docker login setup to use authenticated docker commands.

http://b/213335159