### PR TITLE
Remove flake8

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -179,7 +179,6 @@ RUN apt-get install -y libfreetype6-dev && \
     pip install wordcloud && \
     pip install xgboost && \
     pip install pydot && \
-    pip install flake8 && \
     # Pinned because it breaks theano test with the latest version (b/178107003).
     pip install theano-pymc==1.0.11 && \
     pip install python-Levenshtein && \


### PR DESCRIPTION
This package is causing a downgrade of the `importlib-metadata` package which is causing a cascading number of reinstalls: https://github.com/PyCQA/flake8/blob/9f608813b80caf5a966e44d4bfb5e032159eb3e2/setup.cfg#L45

Flake8 is a style checker for Python but we are not using it AFAIK. We don't have Jupyter plugins for it either.