### PR TITLE
Add neptune-client package

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -36,7 +36,7 @@ ARG TORCHAUDIO_VERSION
 ARG TORCHTEXT_VERSION
 ARG TORCHVISION_VERSION
 
-# Disable pesky logs like: KMP_AFFINITY: pid 6121 tid 6121 thread 0 bound to OS proc set 0 
+# Disable pesky logs like: KMP_AFFINITY: pid 6121 tid 6121 thread 0 bound to OS proc set 0
 # See: https://stackoverflow.com/questions/57385766/disable-tensorflow-log-information
 ENV KMP_WARNINGS=0
 # Also make the KMP logs noverbose.
@@ -217,7 +217,7 @@ RUN pip install ibis-framework && \
 
 RUN pip install scipy && \
     pip install scikit-learn && \
-    # Scikit-learn accelerated library for x86 
+    # Scikit-learn accelerated library for x86
     pip install scikit-learn-intelex && \
     # HDF5 support
     pip install h5py && \
@@ -328,7 +328,7 @@ RUN pip install mpld3 && \
     pip install kaggle && \
     /tmp/clean-layer.sh
 
-RUN pip install tensorpack && \   
+RUN pip install tensorpack && \
     # Add google PAIR-code Facets
     cd /opt/ && git clone https://github.com/PAIR-code/facets && cd facets/ && jupyter nbextension install facets-dist/ --user && \
     export PYTHONPATH=$PYTHONPATH:/opt/facets/facets_overview/python/ && \
@@ -365,7 +365,7 @@ RUN pip install --upgrade cython && \
     # b/183041606#comment5: the Kaggle data proxy doesn't support these APIs. If the library is missing, it falls back to using a regular BigQuery query to fetch data.
     pip uninstall -y google-cloud-bigquery-storage && \
     # After launch this should be installed from pip
-    pip install git+https://github.com/googleapis/python-aiplatform.git@mb-release && \ 
+    pip install git+https://github.com/googleapis/python-aiplatform.git@mb-release && \
     pip install ortools && \
     pip install scattertext && \
     # Pandas data reader
@@ -449,6 +449,7 @@ RUN pip install bleach && \
     ###########
 
 RUN pip install flashtext && \
+    pip install neptune-client\
     pip install wandb && \
     # b/214080882 blake3 0.3.0 is not compatible with vaex.
     pip install blake3==0.2.1 && \
@@ -483,7 +484,7 @@ RUN pip install flashtext && \
     pip install plotly_express && \
     pip install albumentations && \
     pip install catalyst && \
-    # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want. 
+    # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
     pip install osmnx==1.1.1 && \
     apt-get -y install libspatialindex-dev && \
     pip install pytorch-ignite && \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -449,7 +449,7 @@ RUN pip install bleach && \
     ###########
 
 RUN pip install flashtext && \
-    pip install neptune-client\
+    pip install neptune-client &&\
     pip install wandb && \
     # b/214080882 blake3 0.3.0 is not compatible with vaex.
     pip install blake3==0.2.1 && \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -449,7 +449,7 @@ RUN pip install bleach && \
     ###########
 
 RUN pip install flashtext && \
-    pip install neptune-client &&\
+    pip install neptune-client && \
     pip install wandb && \
     # b/214080882 blake3 0.3.0 is not compatible with vaex.
     pip install blake3==0.2.1 && \

--- a/tests/test_neptune.py
+++ b/tests/test_neptune.py
@@ -1,0 +1,22 @@
+import unittest
+
+try:
+    # neptune-client=0.9.0+ package structure
+    import neptune.new as neptune
+except ImportError:
+    # neptune-client>=1.0.0 package structure
+    import neptune
+
+
+class TestNeptune(unittest.TestCase):
+    def test_version(self):
+        self.assertIsNotNone(neptune.__version__)
+
+    def test_init_offline_run(self):
+        run = neptune.init(mode="offline")
+        run["foo"] = "bar"
+        run["baz"].log(42)
+        self.assertTrue("foo" in run.get_structure())
+        self.assertTrue("baz" in run.get_structure())
+
+

--- a/tests/test_neptune.py
+++ b/tests/test_neptune.py
@@ -13,7 +13,7 @@ class TestNeptune(unittest.TestCase):
         self.assertIsNotNone(neptune.__version__)
 
     def test_init_offline_run(self):
-        run = neptune.init(mode="offline")
+        run = neptune.init_run(mode="offline")
         run["foo"] = "bar"
         run["baz"].log(42)
         self.assertTrue("foo" in run.get_structure())

--- a/tests/test_neptune.py
+++ b/tests/test_neptune.py
@@ -18,5 +18,3 @@ class TestNeptune(unittest.TestCase):
         run["baz"].log(42)
         self.assertTrue("foo" in run.get_structure())
         self.assertTrue("baz" in run.get_structure())
-
-


### PR DESCRIPTION
Hi guys 😃 

I'd like to have [Neptune.ai](https://github.com/neptune-ai/neptune-client) (a Metadata Store for MLOps) preinstalled on Kaggle. This will help me and other ML practitioners (Data Scientists, Researchers, or MLEs) quickly import it and track their ML experiments without worrying about installing the Neptune Python client on Kaggle kernels each time.

This PR adds:
- The [Neptune](https://github.com/neptune-ai/neptune-client)  Python client package 📦 
- And tests for Neptune 🧪 

Thank you very much!