### PR TITLE
Install mock package

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -326,6 +326,7 @@ RUN pip install mpld3 && \
     pip install geoplot && \
     pip install eli5 && \
     pip install kaggle && \
+    pip install mock && \
     /tmp/clean-layer.sh
 
 RUN pip install tensorpack && \   

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -145,7 +145,7 @@ pipeline {
                 stage('Test on T4x2') {
                   agent { label 'ephemeral-linux-gpu-t4x2' }
                   options {
-                    timeout(time: 20, unit: 'MINUTES')
+                    timeout(time: 30, unit: 'MINUTES')
                   }
                   steps {
                     sh '''#!/bin/bash


### PR DESCRIPTION
The error in the Dec 13th build is `ModuleNotFoundError: No module named 'mock'`.

Also increase timeout for T4 tests.

http://b/262387811