### PR TITLE
add pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,19 +20,6 @@ repos:
       - id: check-docstring-first
       - id: detect-private-key
 
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-      - id: pyupgrade
-        args: [--py38-plus]
-        name: Upgrade code
-
-  #- repo: https://github.com/psf/black
-  #  rev: 22.12.0
-  #  hooks:
-  #    - id: black
-  #      name: Black code
-
   - repo: https://github.com/executablebooks/mdformat
     rev: 0.7.16
     hooks:
@@ -41,11 +28,6 @@ repos:
           - mdformat-gfm
           # - mdformat-black
           - mdformat_frontmatter
-
-  - repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
-    hooks:
-      - id: yesqa
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.240

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,10 +48,7 @@ repos:
       - id: yesqa
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.226
+    rev: v0.0.240
     hooks:
       - id: ruff
-        # Respect `exclude` and `extend-exclude` settings.
-        args:
-          - "--fix"
-          - "--force-exclude"
+        args: ["--fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,9 +39,8 @@ repos:
       - id: mdformat
         additional_dependencies:
           - mdformat-gfm
-          - mdformat-black
+          # - mdformat-black
           - mdformat_frontmatter
-        exclude: CHANGELOG.md
 
   - repo: https://github.com/asottile/yesqa
     rev: v1.4.0
@@ -49,7 +48,7 @@ repos:
       - id: yesqa
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.226'
+    rev: v0.0.226
     hooks:
       - id: ruff
         # Respect `exclude` and `extend-exclude` settings.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,58 @@
+default_language_version:
+  python: python3.8
+
+ci:
+  autofix_prs: true
+  autoupdate_commit_msg: '[pre-commit.ci] pre-commit suggestions'
+  # submodules: true
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-case-conflict
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+      - id: check-added-large-files
+      - id: check-docstring-first
+      - id: detect-private-key
+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+      - id: pyupgrade
+        args: [--py38-plus]
+        name: Upgrade code
+
+  #- repo: https://github.com/psf/black
+  #  rev: 22.12.0
+  #  hooks:
+  #    - id: black
+  #      name: Black code
+
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.16
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-gfm
+          - mdformat-black
+          - mdformat_frontmatter
+        exclude: CHANGELOG.md
+
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.4.0
+    hooks:
+      - id: yesqa
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.226'
+    hooks:
+      - id: ruff
+        # Respect `exclude` and `extend-exclude` settings.
+        args:
+          - "--fix"
+          - "--force-exclude"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ line-length = 120
 select = [
     "E", "W",  # see: https://pypi.org/project/pycodestyle
     "F",  # see: https://pypi.org/project/pyflakes
-    "D",  # see: https://pypi.org/project/pydocstyle
-    "N",  # see: https://pypi.org/project/pep8-naming
+#    "D",  # see: https://pypi.org/project/pydocstyle
+#    "N",  # see: https://pypi.org/project/pep8-naming
 ]
 #extend-select = [
 #    "C4",  # see: https://pypi.org/project/flake8-comprehensions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[tool.black]
+# https://github.com/psf/black
+line-length = 120
+exclude = "(.eggs|.git|.hg|.mypy_cache|.venv|_build|buck-out|build|dist)"
+
+
+[tool.ruff]
+line-length = 120
+# Enable Pyflakes `E` and `F` codes by default.
+select = [
+    "E", "W",  # see: https://pypi.org/project/pycodestyle
+    "F",  # see: https://pypi.org/project/pyflakes
+    "D",  # see: https://pypi.org/project/pydocstyle
+    "N",  # see: https://pypi.org/project/pep8-naming
+]
+#extend-select = [
+#    "C4",  # see: https://pypi.org/project/flake8-comprehensions
+#    "PT",  # see: https://pypi.org/project/flake8-pytest-style
+#    "RET",  # see: https://pypi.org/project/flake8-return
+#    "SIM",  # see: https://pypi.org/project/flake8-simplify
+#]
+ignore = [
+    "E731",  # Do not assign a lambda expression, use a def
+]
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".eggs",
+    ".git",
+    ".ruff_cache",
+    "_build",
+    "build",
+    "dist",
+]
+ignore-init-module-imports = true
+
+[tool.ruff.mccabe]
+# Unlike Flake8, default to a complexity level of 10.
+max-complexity = 10


### PR DESCRIPTION
I may suggest use come automated formatting, for example, pre-commit, which you can also install as a [bot](https://pre-commit.ci/) that would automatically fix all open PRs. With this PR, I am just setting python check without any formatting (just adding black to config but disabling hook in the pre-commit)