### PR TITLE
Increase timeout for P100 tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ pipeline {
                 stage('Test on P100') {
                   agent { label 'ephemeral-linux-gpu' }
                   options {
-                    timeout(time: 20, unit: 'MINUTES')
+                    timeout(time: 30, unit: 'MINUTES')
                   }
                   steps {
                     sh '''#!/bin/bash


### PR DESCRIPTION
Tests run fine in 155s when I kick them off manually from a `linux-gpu-*` test worker. Pulling the image + waiting for a GPU worker sometimes takes more time.