### PR TITLE
Upgrade cudnn to 8.2 instead of 8.0.5 for JAX

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -149,7 +149,7 @@ RUN pip install lightgbm==$LIGHTGBM_VERSION && \
 
 # Install JAX
 {{ if eq .Accelerator "gpu" }}
-RUN pip install jax[cuda11_cudnn805] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html && \
+RUN pip install jax[cuda11_cudnn82] -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html && \
     /tmp/clean-layer.sh
 {{ else }}
 RUN pip install jax[cpu] && \


### PR DESCRIPTION
This is causing some issues with folks trying to use JAX.jit.

Jax requires 8.2 for CUDA 11.4 (which we are using)

```
# Installs the wheel compatible with Cuda >= 11.4 and cudnn >= 8.2
pip install "jax[cuda11_cudnn82]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
```