### PR TITLE
upgrade jupyter-server

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -593,9 +593,9 @@ RUN pip install --upgrade dask && \
     mkdir -p /etc/ipython/ && echo "c = get_config(); c.IPKernelApp.matplotlib = 'inline'" > /etc/ipython/ipython_config.py && \
     # Temporary patch for broken libpixman 0.38 in conda-forge, symlink to system libpixman 0.34 untile conda package gets updated to 0.38.5 or higher.
     ln -sf /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.34.0 /opt/conda/lib/libpixman-1.so.0.38.0 && \
-    /tmp/clean-layer.sh && \
     # upgrade jupyter-server to version > 2.x
-    pip install --force-reinstall --no-deps jupyter_server>=2.*
+    pip install --force-reinstall --no-deps jupyter_server>=2.* && \
+    /tmp/clean-layer.sh
 
 RUN pip install setuptools==59.8.0 && pip install -e git+https://github.com/SohierDane/BigQuery_Helper#egg=bq_helper
 

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -593,7 +593,9 @@ RUN pip install --upgrade dask && \
     mkdir -p /etc/ipython/ && echo "c = get_config(); c.IPKernelApp.matplotlib = 'inline'" > /etc/ipython/ipython_config.py && \
     # Temporary patch for broken libpixman 0.38 in conda-forge, symlink to system libpixman 0.34 untile conda package gets updated to 0.38.5 or higher.
     ln -sf /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.34.0 /opt/conda/lib/libpixman-1.so.0.38.0 && \
-    /tmp/clean-layer.sh
+    /tmp/clean-layer.sh && \
+    # upgrade jupyter-server to version > 2.x
+    pip install --force-reinstall --no-deps jupyter_server>=2.*
 
 RUN pip install setuptools==59.8.0 && pip install -e git+https://github.com/SohierDane/BigQuery_Helper#egg=bq_helper
 

--- a/tests/test_jupyter_server.py
+++ b/tests/test_jupyter_server.py
@@ -3,14 +3,13 @@ import unittest
 
 
 class TestJupyterServer(unittest.TestCase):
-    
-    
     def test_version(self):
         from packaging.version import parse as parse_version
         from importlib.metadata import version as pckg_version
-        self.assertTrue(parse_version(pckg_version('jupyter_server')) >= parse_version('2.0'))
-        
+
+        self.assertTrue(parse_version(pckg_version("jupyter_server")) >= parse_version("2.0"))
+
     def test_terminals(self):
         import jupyter_server_terminals
 
-    
+        self.assertTrue(hasattr(jupyter_server_terminals, "version_info"))

--- a/tests/test_jupyter_server.py
+++ b/tests/test_jupyter_server.py
@@ -1,0 +1,16 @@
+import os
+import unittest
+
+
+class TestJupyterServer(unittest.TestCase):
+    
+    
+    def test_version(self):
+        from packaging.version import parse as parse_version
+        from importlib.metadata import version as pckg_version
+        self.assertTrue(parse_version(pckg_version('jupyter_server')) >= parse_version('2.0'))
+        
+    def test_terminals(self):
+        import jupyter_server_terminals
+
+    


### PR DESCRIPTION
This patch upgrades `jupyter_server` 🆙  to version `2.x` 

- Fixes #1247 
- Fixes #1246

Note: GitHub actions [here demonstrate that images build and publish](https://github.com/maciejskorski/docker-python)