### PR TITLE
Add rapidfuzz existence test

### DIFF
--- a/tests/test_rapidfuzz.py
+++ b/tests/test_rapidfuzz.py
@@ -1,5 +1,7 @@
 import unittest
 
+# needed for the Word Error Rate metric:
+# competitions/metrics/python/deployed_metrics/general_use_metrics/word_error_rate.py
 import rapidfuzz
 
 class TestRapidfuzz(unittest.TestCase):

--- a/tests/test_rapidfuzz.py
+++ b/tests/test_rapidfuzz.py
@@ -1,0 +1,11 @@
+import unittest
+
+import rapidfuzz
+
+class TestRapidfuzz(unittest.TestCase):
+    def test_distance(self):
+        distance = rapidfuzz.distance.Levenshtein.distance(
+            'Levenshtein', 'Lenvinsten'
+        )
+
+        self.assertEqual(4, distance)


### PR DESCRIPTION
Existence test for the `rapidfuzz` library, needed for the [Word Error Rate](https://github.com/Kaggle/competitions/pull/260) metric.