### PR TITLE
Unpin accelerate to fix transformers pipeline

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -528,7 +528,7 @@ RUN pip install flashtext \
         git+https://github.com/Philmod/catalyst.git@fix-fp16#egg=catalyst \
         # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
         osmnx==1.1.1 \
-        keras-cv && \
+        keras-cv=0.5.0 && \
     apt-get -y install libspatialindex-dev
 RUN pip install pytorch-ignite \
         qgrid \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -524,7 +524,7 @@ RUN pip install flashtext \
         albumentations \
         accelerate \
         # b/290207097 use main catalyst package when bug fixed
-        git+https://github.com/Philmod/catalyst.git@fix-fp16 \
+        git+https://github.com/Philmod/catalyst.git@fix-fp16#egg=catalyst \
         # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
         osmnx==1.1.1 && \
     apt-get -y install libspatialindex-dev

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -528,6 +528,7 @@ RUN pip install flashtext \
         git+https://github.com/Philmod/catalyst.git@fix-fp16#egg=catalyst \
         # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
         osmnx==1.1.1 \
+        # b/290392955 version 0.5.1 breaks the test
         keras-cv=0.5.0 && \
     apt-get -y install libspatialindex-dev
 RUN pip install pytorch-ignite \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -523,7 +523,8 @@ RUN pip install flashtext \
         plotly_express \
         albumentations \
         accelerate \
-        # b/290207097 use main catalyst package when bug fixed
+        # b/290207097 switch back to the pip catalyst package when bug fixed
+        # https://github.com/catalyst-team/catalyst/issues/1440
         git+https://github.com/Philmod/catalyst.git@fix-fp16#egg=catalyst \
         # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
         osmnx==1.1.1 && \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -529,7 +529,7 @@ RUN pip install flashtext \
         # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
         osmnx==1.1.1 \
         # b/290392955 version 0.5.1 breaks the test
-        keras-cv=0.5.0 && \
+        keras-cv==0.5.0 && \
     apt-get -y install libspatialindex-dev
 RUN pip install pytorch-ignite \
         qgrid \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -524,7 +524,7 @@ RUN pip install flashtext \
         albumentations \
         accelerate \
         # b/290207097 use main catalyst package when bug fixed
-        git+https://https://github.com/Philmod/catalyst.git@fix-fp16 \
+        git+https://github.com/Philmod/catalyst.git@fix-fp16 \
         # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
         osmnx==1.1.1 && \
     apt-get -y install libspatialindex-dev

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -522,9 +522,9 @@ RUN pip install flashtext \
         optuna \
         plotly_express \
         albumentations \
-        # b/290207097 catalyst requires accelerate but it breaks with the version >0.15
-        accelerate==0.15.0 \
-        catalyst \
+        accelerate \
+        # b/290207097 use main catalyst package when bug fixed
+        git+https://https://github.com/Philmod/catalyst.git@fix-fp16 \
         # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
         osmnx==1.1.1 && \
     apt-get -y install libspatialindex-dev

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -522,8 +522,7 @@ RUN pip install flashtext \
         optuna \
         plotly_express \
         albumentations \
-        # b/254245259 catalyst requires accelerate but it breaks with the version 0.13.1
-        accelerate==0.12.0 \
+        accelerate \
         catalyst \
         # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
         osmnx==1.1.1 && \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -522,7 +522,8 @@ RUN pip install flashtext \
         optuna \
         plotly_express \
         albumentations \
-        accelerate \
+        # b/290207097 catalyst requires accelerate but it breaks with the version >0.15
+        accelerate==0.15.0 \
         catalyst \
         # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
         osmnx==1.1.1 && \

--- a/tests/test_transformers.py
+++ b/tests/test_transformers.py
@@ -2,6 +2,7 @@ import unittest
 
 import torch
 from transformers import AdamW
+import transformers.pipelines # verify this import works
 
 
 class TestTransformers(unittest.TestCase):


### PR DESCRIPTION
Also: 
- use fork of Catalyst to work with the latest Accelerate
- pin keras-cv, the latest version broke test

http://b/254245259