### PR TITLE
Unpin keras-cv

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -528,8 +528,7 @@ RUN pip install flashtext \
         git+https://github.com/Philmod/catalyst.git@fix-fp16#egg=catalyst \
         # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
         osmnx==1.1.1 \
-        # b/290392955 version 0.5.1 breaks the test
-        keras-cv==0.5.0 && \
+        keras-cv && \
     apt-get -y install libspatialindex-dev
 RUN pip install pytorch-ignite \
         qgrid \

--- a/tests/test_kerascv.py
+++ b/tests/test_kerascv.py
@@ -13,9 +13,6 @@ class TestKerasCV(unittest.TestCase):
         )
         image = keras.utils.load_img('/input/tests/data/face.jpg')
         image = np.array(image)
-        keras_cv.visualization.plot_image_gallery(
-            [image], rows=1, cols=1, value_range=(0, 255), show=True, scale=4
-        )
         predictions = classifier.predict(np.expand_dims(image, axis=0))
         top_classes = predictions[0].argsort(axis=-1)
         self.assertEqual(1000, len(top_classes))


### PR DESCRIPTION
That line is broken in the last version of keras-cv, but wasn't actually used in the test.

I also created a [bug](https://github.com/keras-team/keras-cv/issues/1923) on keras-cv repository.

http://b/290392955