### PR TITLE
Add Package target-permutation-importances

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -653,6 +653,8 @@ RUN rm /opt/conda/lib/libtinfo.so.6 && ln -s /usr/lib/x86_64-linux-gnu/libtinfo.
 # b/276358430 fix Jupyter lsp freezing up the jupyter server
 RUN pip install "jupyter-lsp==1.5.1"
 
+RUN pip install "target-permutation-importances"
+
 # Set backend for matplotlib
 ENV MPLBACKEND "agg"
 

--- a/tests/test_target_permutation_importances.py
+++ b/tests/test_target_permutation_importances.py
@@ -1,0 +1,65 @@
+import unittest
+
+import pandas as pd
+from sklearn.datasets import load_breast_cancer
+from sklearn.ensemble import RandomForestClassifier
+import target_permutation_importances as tpi
+
+
+class TestTargetPermutationImportances(unittest.TestCase):
+    def test_with_functional_api(self):
+        data = load_breast_cancer()
+
+        # Convert to a pandas dataframe
+        Xpd = pd.DataFrame(data.data, columns=data.feature_names)
+
+        # Compute permutation importances with default settings
+        result_df = tpi.compute(
+            model_cls=RandomForestClassifier,  # The constructor/class of the model.
+            model_cls_params={},  # The parameters to pass to the model constructor. Update this based on your needs.
+            model_fit_params={},  # The parameters to pass to the model fit method. Update this based on your needs.
+            X=Xpd,  # pd.DataFrame, np.ndarray
+            y=data.target,  # pd.Series, np.ndarray
+            num_actual_runs=2,
+            num_random_runs=3,
+            # Options: {compute_permutation_importance_by_subtraction, compute_permutation_importance_by_division}
+            # Or use your own function to calculate.
+            permutation_importance_calculator=tpi.compute_permutation_importance_by_subtraction,
+        )
+
+        self.assertTrue(isinstance(result_df, pd.DataFrame))
+        self.assertTrue("feature" in result_df.columns)
+        self.assertTrue("importance" in result_df.columns)
+        self.assertTrue(result_df.shape[0] == Xpd.shape[1])
+        self.assertTrue(result_df["feature"].isna().sum() == 0)
+        self.assertTrue(result_df["importance"].isna().sum() == 0)
+
+    def test_with_sklearn_api(self):
+        data = load_breast_cancer()
+
+        # Convert to a pandas dataframe
+        Xpd = pd.DataFrame(data.data, columns=data.feature_names)
+
+        # Compute permutation importances with default settings
+        wrapped_model = tpi.TargetPermutationImportancesWrapper(
+            model_cls=RandomForestClassifier,  # The constructor/class of the model.
+            model_cls_params={},  # The parameters to pass to the model constructor. Update this based on your needs.
+            num_actual_runs=2,
+            num_random_runs=10,
+            # Options: {compute_permutation_importance_by_subtraction, compute_permutation_importance_by_division}
+            # Or use your own function to calculate.
+            permutation_importance_calculator=tpi.compute_permutation_importance_by_subtraction,
+        )
+        wrapped_model.fit(
+            X=Xpd,  # pd.DataFrame, np.ndarray
+            y=data.target,  # pd.Series, np.ndarray
+            # And other fit parameters for the model.
+        )
+        # Get the feature importances as a pandas dataframe
+        result_df = wrapped_model.feature_importances_df
+        self.assertTrue(isinstance(result_df, pd.DataFrame))
+        self.assertTrue("feature" in result_df.columns)
+        self.assertTrue("importance" in result_df.columns)
+        self.assertTrue(result_df.shape[0] == Xpd.shape[1])
+        self.assertTrue(result_df["feature"].isna().sum() == 0)
+        self.assertTrue(result_df["importance"].isna().sum() == 0)


### PR DESCRIPTION
Hi, I created a python package that computes Null Importances, the popular feature ranking method among kaggle competitions. The package is fully tested within the repo https://github.com/kingychiu/target-permutation-importances.

I built the Kaggle docker images on an AWS EC2 instance and run tests successfully. See the results:

Without GPU:
```
[ec2-user@ip-172-31-59-174 docker-python]$ sudo ./test -p test_target_permutation_importances.py
+ docker run --rm --net=none -v /tmp/python-build:/tmp/python-build kaggle/python-build rm -rf /tmp/python-build/devshm /tmp/python-build/kaggle /tmp/python-build/tmp /tmp/python-build/working
+ docker rm jupyter_test
Error: No such container: jupyter_test
+ true
+ mkdir -p /tmp/python-build/tmp
+ mkdir -p /tmp/python-build/devshm
+ mkdir -p /tmp/python-build/working
+ mkdir -p /tmp/python-build/kaggle
+ '[' test_target_permutation_importances.py == 'test*.py' ']'
+ docker run --rm -t --read-only --net=none -e HOME=/tmp -e KAGGLE_DATA_PROXY_TOKEN=test-key -e KAGGLE_USER_SECRETS_TOKEN_KEY=test-secrets-key -e KAGGLE_URL_BASE=http://127.0.0.1:0 -e KAGGLE_DATA_PROXY_URL=http://127.0.0.1:8000 -e KAGGLE_DATA_PROXY_PROJECT=test -e TF_FORCE_GPU_ALLOW_GROWTH=true -e XLA_PYTHON_CLIENT_PREALLOCATE=false --hostname localhost --shm-size=2g -v /home/ec2-user/a/docker-python:/input:ro -v /tmp/python-build/working:/working -v /tmp/python-build/tmp:/tmp -v /tmp/python-build/devshm:/dev/shm -v /tmp/python-build/kaggle:/kaggle -w=/working kaggle/python-build /bin/bash -c 'python -m unittest discover -s /input/tests -p test_target_permutation_importances.py -v'
/opt/conda/lib/python3.10/site-packages/scipy/__init__.py:146: UserWarning: A NumPy version >=1.16.5 and <1.23.0 is required for this version of SciPy (detected version 1.23.5
  warnings.warn(f"A NumPy version >={np_minversion} and <{np_maxversion}"
test_with_functional_api (test_target_permutation_importances.TestTargetPermutationImportances) ... Running 2 actual runs and 3 random runs
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  3.12it/s]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  2.59it/s]
ok
test_with_sklearn_api (test_target_permutation_importances.TestTargetPermutationImportances) ... Running 2 actual runs and 10 random runs
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████���████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  3.28it/s]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:03<00:00,  2.53it/s]
ok

----------------------------------------------------------------------
Ran 2 tests in 6.448s

OK
```


With GPU:
```
[ec2-user@ip-172-31-59-174 docker-python]$ sudo ./test -p test_target_permutation_importances.py -g
+ docker run --rm --net=none -v /tmp/python-build:/tmp/python-build kaggle/python-gpu-build rm -rf /tmp/python-build/devshm /tmp/python-build/kaggle /tmp/python-build/tmp /tmp/python-build/working
+ docker rm jupyter_test
Error: No such container: jupyter_test
+ true
+ mkdir -p /tmp/python-build/tmp
+ mkdir -p /tmp/python-build/devshm
+ mkdir -p /tmp/python-build/working
+ mkdir -p /tmp/python-build/kaggle
+ '[' test_target_permutation_importances.py == 'test*.py' ']'
+ docker run --rm -t --read-only --net=none -e HOME=/tmp -e KAGGLE_DATA_PROXY_TOKEN=test-key -e KAGGLE_USER_SECRETS_TOKEN_KEY=test-secrets-key -e KAGGLE_URL_BASE=http://127.0.0.1:0 -e KAGGLE_DATA_PROXY_URL=http://127.0.0.1:8000 -e KAGGLE_DATA_PROXY_PROJECT=test -e TF_FORCE_GPU_ALLOW_GROWTH=true -e XLA_PYTHON_CLIENT_PREALLOCATE=false --hostname localhost --shm-size=2g -v /home/ec2-user/a/docker-python:/input:ro -v /tmp/python-build/working:/working -v /tmp/python-build/tmp:/tmp -v /tmp/python-build/devshm:/dev/shm -v /tmp/python-build/kaggle:/kaggle -w=/working -v /tmp/empty_dir:/usr/local/cuda/lib64/stubs:ro kaggle/python-gpu-build /bin/bash -c 'python -m unittest discover -s /input/tests -p test_target_permutation_importances.py -v'
/opt/conda/lib/python3.10/site-packages/scipy/__init__.py:146: UserWarning: A NumPy version >=1.16.5 and <1.23.0 is required for this version of SciPy (detected version 1.23.5
  warnings.warn(f"A NumPy version >={np_minversion} and <{np_maxversion}"
test_with_functional_api (test_target_permutation_importances.TestTargetPermutationImportances) ... Running 2 actual runs and 3 random runs
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  3.52it/s]
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:01<00:00,  2.75it/s]
ok
test_with_sklearn_api (test_target_permutation_importances.TestTargetPermutationImportances) ... Running 2 actual runs and 10 random runs
100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00,  3.54it/s]
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 10/10 [00:03<00:00,  2.74it/s]
ok

----------------------------------------------------------------------
Ran 2 tests in 5.907s

OK
```


I only run the new test file I added, because I encounter error about GCP BigQuery Auth when I try to run the full test.

Please let me know if you have any questions.