### PR TITLE
Add printenv to docker image diff script.

### DIFF
--- a/diff
+++ b/diff
@@ -98,7 +98,7 @@ if [[ -n "$PACKAGE_NAME" ]]; then
     echo "Package: $PACKAGE_NAME"
     CMDS=("python /tools/pip_list_versions.py $PACKAGE_NAME | sort")
 else
-    CMDS=("pip list --format=freeze" 'cat /etc/os-release | grep -oP "PRETTY_NAME=\"\K([^\"]*)"' "uname -r" "dpkg --list | awk '{print \$2\"==\"\$3}'")
+    CMDS=("pip list --format=freeze" 'cat /etc/os-release | grep -oP "PRETTY_NAME=\"\K([^\"]*)"' "uname -r" "dpkg --list | awk '{print \$2\"==\"\$3}'" "printenv | sort")
 fi
 
 for cmd in "${CMDS[@]}"; do


### PR DESCRIPTION
Useful to see if any environment variables have changed between two docker images.