### PR TITLE
Install newer versions of curl/libcurl

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -95,7 +95,8 @@ ENV PROJ_LIB=/opt/conda/share/proj
 # the remaining pip commands: https://www.anaconda.com/using-pip-in-a-conda-environment/
 RUN conda config --add channels nvidia && \
     conda config --add channels rapidsai && \
-    conda install -c conda-forge mamba && \
+    # b/299991198 remove curl/libcurl install once DLVM base image includes version >= 7.86
+    conda install -c conda-forge mamba curl libcurl && \
     # Base image channel order: conda-forge (highest priority), defaults.
     # End state: rapidsai (highest priority), nvidia, conda-forge, defaults.
     mamba install -y mkl cartopy imagemagick pyproj "shapely<2" && \


### PR DESCRIPTION
Background:
DLVM base image includes curl/libcurl 7.68
mamba requires libcurl >= 7.86
this caused libcurl to be upgraded to 8.2.1 (latest) and the curl tool still uses the old version causing the mismatch warning.

Solution:
Upgrade curl/libcurl before installing mamba to version

This is installing the following curl/libcurl version:

```
curl               pkgs/main/linux-64::curl-8.2.1-hdbd6064_0
libcurl            pkgs/main/linux-64::libcurl-8.2.1-h251f7ec_0
```

http://b/299991198