### PR TITLE
Pin tensorflowjs

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -520,7 +520,8 @@ RUN pip install flashtext \
         pyarabic \
         pandasql \
         tensorflow_hub \
-        tensorflowjs \
+        # b/300552705 Remove pin once we upgrade to TensorFlow 2.13
+        tensorflowjs==4.10 \
         jieba  \
         # ggplot is broken and main repo does not merge and release https://github.com/yhat/ggpy/pull/668
         https://github.com/hbasria/ggpy/archive/0.11.5.zip \


### PR DESCRIPTION
A new version of tensorflowjs has been released and requires tensorflow
>= 2.13. We are currently using 2.12 and this is causing a test failure.

Full context in bug.

http://b/300552705