### PR TITLE
Fix eli5 import

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -240,7 +240,8 @@ RUN pip install ibis-framework && \
     /tmp/clean-layer.sh
 
 RUN pip install scipy \
-        scikit-learn \
+        # b/302136621 Fix eli5 import for learntools
+        "scikit-learn<1.3" \
         # Scikit-learn accelerated library for x86
         scikit-learn-intelex>=2023.0.1 \
         # HDF5 support


### PR DESCRIPTION
eli5 will not import successfully with learntools 1.3 right now, pinning learntools back until these two are compatible

http://b/302136621