### PR TITLE
apt-get update --allow-releaseinfo-change

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -79,7 +79,7 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --
 # Use a fixed apt-get repo to stop intermittent failures due to flaky httpredir connections,
 # as described by Lionel Chan at http://stackoverflow.com/a/37426929/5881346
 RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list && \
-    apt-get update && \
+    apt-get update --allow-releaseinfo-change && \
     # Needed by lightGBM (GPU build)
     # https://lightgbm.readthedocs.io/en/latest/GPU-Tutorial.html#build-lightgbm
     apt-get install -y build-essential unzip cmake libboost-dev libboost-system-dev libboost-filesystem-dev p7zip-full && \


### PR DESCRIPTION
This PR fixes the following error when running `./build`

```
 => ERROR [ 8/58] RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list &&     apt-get update &&     apt-get install -y build-essential unzip cmake lib  4.9s
------
 > [ 8/58] RUN sed -i "s/httpredir.debian.org/debian.uchicago.edu/" /etc/apt/sources.list &&     apt-get update &&     apt-get install -y build-essential unzip cmake libboost-dev libboost-system-dev libboost-filesystem-dev p7zip-full &&     apt-get install -y openssh-client &&     /tmp/clean-layer.sh:
0.699 Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
0.701 Get:2 http://archive.ubuntu.com/ubuntu focal-updates InRelease [114 kB]
0.884 Get:3 http://packages.cloud.google.com/apt gcsfuse-focal InRelease [1299 B]
0.954 Get:4 http://security.ubuntu.com/ubuntu focal-security InRelease [114 kB]
1.132 Get:5 https://packages.cloud.google.com/apt cloud-sdk InRelease [6361 B]
1.248 Get:6 http://archive.ubuntu.com/ubuntu focal-backports InRelease [108 kB]
1.363 Get:7 https://packages.cloud.google.com/apt cloud-sdk/main amd64 Packages [526 kB]
1.397 Get:8 http://archive.ubuntu.com/ubuntu focal-updates/restricted amd64 Packages [3046 kB]
1.697 Get:9 http://security.ubuntu.com/ubuntu focal-security/restricted amd64 Packages [2896 kB]
2.507 Get:10 http://security.ubuntu.com/ubuntu focal-security/main amd64 Packages [3109 kB]
2.713 Get:11 http://security.ubuntu.com/ubuntu focal-security/universe amd64 Packages [1117 kB]
2.769 Get:12 http://security.ubuntu.com/ubuntu focal-security/multiverse amd64 Packages [29.3 kB]
2.857 Get:13 http://archive.ubuntu.com/ubuntu focal-updates/main amd64 Packages [3597 kB]
3.810 Get:14 http://archive.ubuntu.com/ubuntu focal-updates/universe amd64 Packages [1421 kB]
4.082 Get:15 http://archive.ubuntu.com/ubuntu focal-updates/multiverse amd64 Packages [32.0 kB]
4.154 Reading package lists...
4.836 E: Repository 'http://packages.cloud.google.com/apt gcsfuse-focal InRelease' changed its 'Origin' value from 'gcsfuse-jessie' to 'namespaces/gcs-fuse-prod/repositories/gcsfuse-focal'
4.836 E: Repository 'http://packages.cloud.google.com/apt gcsfuse-focal InRelease' changed its 'Label' value from 'gcsfuse-jessie' to 'namespaces/gcs-fuse-prod/repositories/gcsfuse-focal'
------
```