### PR TITLE
Pin keras-cv

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -542,8 +542,10 @@ RUN pip install flashtext \
         git+https://github.com/Philmod/catalyst.git@fix-fp16#egg=catalyst \
         # b/206990323 osmx 1.1.2 requires numpy >= 1.21 which we don't want.
         osmnx==1.1.1 \
+        # Remove once `keras-core` is released as Keras
         keras-core \
-        keras-cv \
+        # b/312946339 latest version not compatible with our version of keras
+        keras-cv==0.6.4 \
         keras-nlp && \
     apt-get -y install libspatialindex-dev
 


### PR DESCRIPTION
Latest version fails with:

```
Traceback (most recent call last):
  File "/input/tests/test_keras_cv.py", line 9, in test_inference
    classifier = keras_cv.models.ImageClassifier.from_preset(
  File "/opt/conda/lib/python3.10/site-packages/keras_cv/src/models/task.py", line 196, in from_preset
    return super(cls, calling_cls).from_preset(*args, **kwargs)
  File "/opt/conda/lib/python3.10/site-packages/keras_cv/src/models/task.py", line 147, in from_preset
    model = cls.from_config({**config, **kwargs})
  File "/opt/conda/lib/python3.10/site-packages/keras_cv/src/models/task.py", line 54, in from_config
    config["backbone"] = keras.layers.deserialize(config["backbone"])
  File "/opt/conda/lib/python3.10/site-packages/keras_core/src/layers/__init__.py", line 161, in deserialize
    obj = serialization_lib.deserialize_keras_object(
  File "/opt/conda/lib/python3.10/site-packages/keras_core/src/saving/serialization_lib.py", line 706, in deserialize_keras_object
    instance = cls.from_config(inner_config)
  File "/opt/conda/lib/python3.10/site-packages/keras_cv/src/models/backbones/backbone.py", line 48, in from_config
    return cls(**config)
  File "/opt/conda/lib/python3.10/site-packages/keras_cv/src/models/backbones/efficientnet_v2/efficientnet_v2_backbone.py", line 200, in __init__
    pyramid_level_inputs.append(utils.get_tensor_input_name(x))
  File "/opt/conda/lib/python3.10/site-packages/keras_cv/src/models/utils.py", line 25, in get_tensor_input_name
    return tensor.node.layer.name
AttributeError: 'KerasTensor' object has no attribute 'node'
```

We can remove the pin once we upgrade TensorFlow & Keras.

http://b/312946339