### PR TITLE
Add missing io import in log.py

### DIFF
--- a/patches/log.py
+++ b/patches/log.py
@@ -1,3 +1,4 @@
+import io
 import logging
 import os
 


### PR DESCRIPTION
Fixes #1324.

We setup a custom logger for Kaggle kernels.

Some of this logic could be simplified now that we are using Python 3.8+. I filed b/312963888 for this.

b/312961350