### PR TITLE
Upgrade KerasCV & KerasNLP

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -548,8 +548,8 @@ RUN pip install flashtext \
         # Remove once `keras-core` is released as Keras
         keras-core \
         # TODO(b/315833744) unpin when the alpha versions are merged to the main version.
-        keras-cv==0.8.0.dev0 \
-        keras-nlp==0.7.0.dev3 && \
+        keras-cv \
+        keras-nlp && \
     apt-get -y install libspatialindex-dev
 
 RUN pip install pytorch-ignite \


### PR DESCRIPTION
The latest version of KerasCV (0.8) and KerasNLP (0.7) now include the Kaggle integration.