### PR TITLE
fix(tfhub): check for user secrets token in kaggle_module_resolver

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,8 +15,9 @@ pipeline {
     GIT_COMMIT_AUTHOR = sh(returnStdout: true, script:"git log --format='%an' -n 1 HEAD").trim()
     GIT_COMMIT_SUMMARY = "`<https://github.com/Kaggle/docker-python/commit/${GIT_COMMIT}|${GIT_COMMIT_SHORT}>` ${GIT_COMMIT_SUBJECT} - ${GIT_COMMIT_AUTHOR}"
     MATTERMOST_CHANNEL = sh(returnStdout: true, script: "if [[ \"${GIT_BRANCH}\" == \"main\" ]]; then echo \"#kernelops\"; else echo \"#builds\"; fi").trim()
-    PRETEST_TAG = sh(returnStdout: true, script: "if [[ \"${GIT_BRANCH}\" == \"main\" ]]; then echo \"ci-pretest\"; else echo \"${GIT_BRANCH}-pretest\"; fi").trim()
-    STAGING_TAG = sh(returnStdout: true, script: "if [[ \"${GIT_BRANCH}\" == \"main\" ]]; then echo \"staging\"; else echo \"${GIT_BRANCH}-staging\"; fi").trim()
+    // Use dev branch names as tags, but replace '/' with '-' using sed since docker images don't support forward slash
+    PRETEST_TAG = sh(returnStdout: true, script: "if [[ \"${GIT_BRANCH}\" == \"main\" ]]; then echo \"ci-pretest\"; else echo \"${GIT_BRANCH}-pretest\" | sed 's/\//-/g'; fi").trim()
+    STAGING_TAG = sh(returnStdout: true, script: "if [[ \"${GIT_BRANCH}\" == \"main\" ]]; then echo \"staging\"; else echo \"${GIT_BRANCH}-staging\" | sed 's/\//-/g'; fi").trim()
   }
 
   stages {

--- a/patches/kaggle_module_resolver.py
+++ b/patches/kaggle_module_resolver.py
@@ -7,7 +7,7 @@ from tensorflow_hub import resolver
 url_pattern = re.compile(r"https?://([a-z]+\.)?kaggle.com/models/(?P<owner>[^\\/]+)/(?P<model>[^\\/]+)/frameworks/(?P<framework>[^\\/]+)/variations/(?P<variation>[^\\/]+)/versions/(?P<version>[0-9]+)$")
 
 def _is_on_kaggle_notebook():
-    return os.getenv("KAGGLE_KERNEL_RUN_TYPE") != None
+    return os.getenv("KAGGLE_KERNEL_RUN_TYPE") != None and os.getenv("KAGGLE_USER_SECRETS_TOKEN") != None
 
 def _is_kaggle_handle(handle):
     return url_pattern.match(handle) != None


### PR DESCRIPTION
[b/319516798](http://b/319516798)

**Drive by change**: replace `/` with `-` in docker image tags that are based on `GIT_BRANCH`. `/` in tags are unsupported and caused some integration tests to fail.

