### PR TITLE
Resolves bugs and better supports Cuda libraries like PyTorch and DeepSpeed

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -708,4 +708,6 @@ RUN echo "$GIT_COMMIT" > /etc/git_commit && echo "$BUILD_DATE" > /etc/build_date
 {{ if eq .Accelerator "gpu" }}
 # Remove the CUDA stubs.
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH_NO_STUBS"
+# Add the CUDA home.
+ENV CUDA_HOME=/usr/local/cuda
 {{ end }}


### PR DESCRIPTION
Adding Cuda home environment values helps other libraries avoid unwanted errors, for examples PyTorch and DeepSpeed.
PyTorch and DeepSpeed is just libraries I want to use as examples, ref: 
- https://github.com/microsoft/DeepSpeed/blob/master/op_builder/cpu/cpu_adam.py#L9
- https://github.com/pytorch/pytorch/blob/main/torch/utils/cpp_extension.py#L92, https://pytorch.org/docs/stable/_modules/torch/utils/cpp_extension.html#CppExtension

Please review my PR, thanks for all, @rosbo @djherbis 