### PR TITLE
Bump PyTorch version to 2.2

### DIFF
--- a/tpu/config.txt
+++ b/tpu/config.txt
@@ -7,11 +7,11 @@ TF_LIBTPU_VERSION=1.9.0
 TF_LINUX_WHEEL_VERSION=manylinux_2_17_x86_64.manylinux2014_x86_64
 JAX_VERSION=0.4.23
 # Supports nightly
-TORCH_VERSION=2.1.0
+TORCH_VERSION=2.2.0
 # https://github.com/pytorch/audio supports nightly
-TORCHAUDIO_VERSION=2.1.0
+TORCHAUDIO_VERSION=2.2.1
 # https://github.com/pytorch/text supports main
-TORCHTEXT_VERSION=0.16.0
+TORCHTEXT_VERSION=0.17.1
 # https://github.com/pytorch/vision supports nightly
-TORCHVISION_VERSION=0.16.0
+TORCHVISION_VERSION=0.17.1
 TORCH_LINUX_WHEEL_VERSION=manylinux_2_28_x86_64


### PR DESCRIPTION
Also bump ecosystem packages (`torchtext`, `torchvision`, `torchaudio`) to latest versions