### PR TITLE
[b/331681978] Add Short URL matching to KaggleFileResolver

### DIFF
--- a/patches/kaggle_module_resolver.py
+++ b/patches/kaggle_module_resolver.py
@@ -11,7 +11,7 @@ def _is_on_kaggle_notebook():
     return os.getenv("KAGGLE_KERNEL_RUN_TYPE") != None and os.getenv("KAGGLE_USER_SECRETS_TOKEN") != None
 
 def _is_kaggle_handle(handle):
-    return url_pattern.match(handle) != None
+    return long_url_pattern.match(handle) != None or short_url_pattern.match(handle) != None
 
 class KaggleFileResolver(resolver.HttpResolverBase):
     def is_supported(self, handle):

--- a/patches/kaggle_module_resolver.py
+++ b/patches/kaggle_module_resolver.py
@@ -4,7 +4,7 @@ import kagglehub
 
 from tensorflow_hub import resolver
 
-url_pattern = re.compile(r"https?://([a-z]+\.)?kaggle.com/models/(?P<owner>[^\\/]+)/(?P<model>[^\\/]+)/frameworks/(?P<framework>[^\\/]+)/variations/(?P<variation>[^\\/]+)/versions/(?P<version>[0-9]+)$")
+url_pattern = re.compile(r"https?://([a-z]+\.)?kaggle.com/models/(?P<owner>[^\\/]+)/(?P<model>[^\\/]+)/(?P<framework>[^\\/]+)/(?P<variation>[^\\/]+)/(?P<version>[0-9]+)$")
 
 def _is_on_kaggle_notebook():
     return os.getenv("KAGGLE_KERNEL_RUN_TYPE") != None and os.getenv("KAGGLE_USER_SECRETS_TOKEN") != None

--- a/patches/kaggle_module_resolver.py
+++ b/patches/kaggle_module_resolver.py
@@ -4,7 +4,8 @@ import kagglehub
 
 from tensorflow_hub import resolver
 
-url_pattern = re.compile(r"https?://([a-z]+\.)?kaggle.com/models/(?P<owner>[^\\/]+)/(?P<model>[^\\/]+)/(?P<framework>[^\\/]+)/(?P<variation>[^\\/]+)/(?P<version>[0-9]+)$")
+short_url_pattern = re.compile(r"https?://([a-z]+\.)?kaggle.com/models/(?P<owner>[^\\/]+)/(?P<model>[^\\/]+)/(?P<framework>[^\\/]+)/(?P<variation>[^\\/]+)/(?P<version>[0-9]+)$")
+long_url_pattern = re.compile(r"https?://([a-z]+\.)?kaggle.com/models/(?P<owner>[^\\/]+)/(?P<model>[^\\/]+)/frameworks/(?P<framework>[^\\/]+)/variations/(?P<variation>[^\\/]+)/versions/(?P<version>[0-9]+)$")
 
 def _is_on_kaggle_notebook():
     return os.getenv("KAGGLE_KERNEL_RUN_TYPE") != None and os.getenv("KAGGLE_USER_SECRETS_TOKEN") != None
@@ -17,5 +18,5 @@ class KaggleFileResolver(resolver.HttpResolverBase):
         return _is_on_kaggle_notebook() and _is_kaggle_handle(handle)    
     
     def __call__(self, handle):
-        m = url_pattern.match(handle)
+        m = long_url_pattern.match(handle) or short_url_pattern.match(handle)
         return kagglehub.model_download(f"{m.group('owner')}/{m.group('model')}/{m.group('framework').lower()}/{m.group('variation')}/{m.group('version')}")

--- a/tests/test_kaggle_module_resolver.py
+++ b/tests/test_kaggle_module_resolver.py
@@ -79,10 +79,16 @@ class KaggleJwtHandler(BaseHTTPRequestHandler):
             self.wfile.write(bytes(f"Unhandled path: {self.path}", "utf-8"))
 
 class TestKaggleModuleResolver(unittest.TestCase):
-    def test_kaggle_resolver_succeeds(self):        
+    def test_kaggle_resolver_long_url_succeeds(self):        
         with create_test_server(KaggleJwtHandler) as addr:
             test_inputs = tf.ones([1,4])
             layer = hub.KerasLayer("https://kaggle.com/models/foo/foomodule/frameworks/TensorFlow2/variations/barvar/versions/2")
+            self.assertEqual([1, 1], layer(test_inputs).shape)
+
+    def test_kaggle_resolver_short_url_succeeds(self):        
+        with create_test_server(KaggleJwtHandler) as addr:
+            test_inputs = tf.ones([1,4])
+            layer = hub.KerasLayer("https://kaggle.com/models/foo/foomodule/TensorFlow2/barvar/2")
             self.assertEqual([1, 1], layer(test_inputs).shape)
 
     def test_kaggle_resolver_not_attached_throws(self):

--- a/tests/test_kaggle_module_resolver.py
+++ b/tests/test_kaggle_module_resolver.py
@@ -64,9 +64,8 @@ class KaggleJwtHandler(BaseHTTPRequestHandler):
 
             # Load the files
             mount_slug = f"{model_ref['ModelSlug']}/{model_ref['Framework']}/{model_ref['InstanceSlug']}/{model_ref['VersionNumber']}"
-            model_path = os.path.join(MOUNT_PATH, mount_slug)
-            os.makedirs(os.path.dirname(model_path))
-            os.symlink('/input/tests/data/saved_model/', model_path, target_is_directory=True)
+            os.makedirs(os.path.dirname(os.path.join(MOUNT_PATH, mount_slug)))
+            os.symlink('/input/tests/data/saved_model/', os.path.join(MOUNT_PATH, mount_slug), target_is_directory=True)
 
             # Return the response
             self.wfile.write(bytes(json.dumps({
@@ -87,9 +86,8 @@ class TestKaggleModuleResolver(unittest.TestCase):
             layer = hub.KerasLayer(model_url)
             self.assertEqual([1, 1], layer(test_inputs).shape)
         # Delete the files that were created in KaggleJwtHandler's do_POST method
-        model_path = os.path.join(MOUNT_PATH, "foomodule/tensorflow2/barvar/2")
-        os.unlink(model_path)
-        os.rmdir(os.path.dirname(model_path))
+        os.unlink(os.path.join(MOUNT_PATH, "foomodule/tensorflow2/barvar/2"))
+        os.rmdir(os.path.dirname(os.path.join(MOUNT_PATH, "foomodule/tensorflow2/barvar/2")))
 
     def test_kaggle_resolver_short_url_succeeds(self):
         model_url = "https://kaggle.com/models/foo/foomodule/TensorFlow2/barvar/2"
@@ -98,9 +96,8 @@ class TestKaggleModuleResolver(unittest.TestCase):
             layer = hub.KerasLayer(model_url)
             self.assertEqual([1, 1], layer(test_inputs).shape)
         # Delete the files that were created in KaggleJwtHandler's do_POST method
-        model_path = os.path.join(MOUNT_PATH, "foomodule/tensorflow2/barvar/2")
-        os.unlink(model_path)
-        os.rmdir(os.path.dirname(model_path))
+        os.unlink(os.path.join(MOUNT_PATH, "foomodule/tensorflow2/barvar/2"))
+        os.rmdir(os.path.dirname(os.path.join(MOUNT_PATH, "foomodule/tensorflow2/barvar/2")))
 
     def test_kaggle_resolver_not_attached_throws(self):
         with create_test_server(KaggleJwtHandler) as addr:

--- a/tests/test_kaggle_module_resolver.py
+++ b/tests/test_kaggle_module_resolver.py
@@ -52,6 +52,7 @@ class KaggleJwtHandler(BaseHTTPRequestHandler):
             request = json.loads(self.rfile.read(content_length))
             model_ref = request["modelRef"]
 
+
             self.send_response(200)
             self.send_header("Content-type", "application/json")
             self.end_headers()
@@ -88,7 +89,7 @@ class TestKaggleModuleResolver(unittest.TestCase):
     def test_kaggle_resolver_short_url_succeeds(self):        
         with create_test_server(KaggleJwtHandler) as addr:
             test_inputs = tf.ones([1,4])
-            layer = hub.KerasLayer("https://kaggle.com/models/foo/foomodule/TensorFlow2/barvar/2")
+            layer = hub.KerasLayer("https://kaggle.com/models/bar/barmodule/pyTorch/barvar/1")
             self.assertEqual([1, 1], layer(test_inputs).shape)
 
     def test_kaggle_resolver_not_attached_throws(self):

--- a/tests/test_kaggle_module_resolver.py
+++ b/tests/test_kaggle_module_resolver.py
@@ -52,7 +52,6 @@ class KaggleJwtHandler(BaseHTTPRequestHandler):
             request = json.loads(self.rfile.read(content_length))
             model_ref = request["modelRef"]
 
-
             self.send_response(200)
             self.send_header("Content-type", "application/json")
             self.end_headers()

--- a/tests/test_kaggle_module_resolver.py
+++ b/tests/test_kaggle_module_resolver.py
@@ -64,8 +64,9 @@ class KaggleJwtHandler(BaseHTTPRequestHandler):
 
             # Load the files
             mount_slug = f"{model_ref['ModelSlug']}/{model_ref['Framework']}/{model_ref['InstanceSlug']}/{model_ref['VersionNumber']}"
-            os.makedirs(os.path.dirname(os.path.join(MOUNT_PATH, mount_slug)))
-            os.symlink('/input/tests/data/saved_model/', os.path.join(MOUNT_PATH, mount_slug), target_is_directory=True)
+            model_path = os.path.join(MOUNT_PATH, mount_slug)
+            os.makedirs(os.path.dirname(model_path))
+            os.symlink('/input/tests/data/saved_model/', model_path, target_is_directory=True)
 
             # Return the response
             self.wfile.write(bytes(json.dumps({
@@ -79,17 +80,27 @@ class KaggleJwtHandler(BaseHTTPRequestHandler):
             self.wfile.write(bytes(f"Unhandled path: {self.path}", "utf-8"))
 
 class TestKaggleModuleResolver(unittest.TestCase):
-    def test_kaggle_resolver_long_url_succeeds(self):        
+    def test_kaggle_resolver_long_url_succeeds(self):
+        model_url = "https://kaggle.com/models/foo/foomodule/frameworks/TensorFlow2/variations/barvar/versions/2"
         with create_test_server(KaggleJwtHandler) as addr:
             test_inputs = tf.ones([1,4])
-            layer = hub.KerasLayer("https://kaggle.com/models/foo/foomodule/frameworks/TensorFlow2/variations/barvar/versions/2")
+            layer = hub.KerasLayer(model_url)
             self.assertEqual([1, 1], layer(test_inputs).shape)
+        # Delete the files that were created in KaggleJwtHandler's do_POST method
+        model_path = os.path.join(MOUNT_PATH, "foomodule/tensorflow2/barvar/2")
+        os.unlink(model_path)
+        os.rmdir(os.path.dirname(model_path))
 
-    def test_kaggle_resolver_short_url_succeeds(self):        
+    def test_kaggle_resolver_short_url_succeeds(self):
+        model_url = "https://kaggle.com/models/foo/foomodule/TensorFlow2/barvar/2"
         with create_test_server(KaggleJwtHandler) as addr:
             test_inputs = tf.ones([1,4])
-            layer = hub.KerasLayer("https://kaggle.com/models/bar/barmodule/pyTorch/barvar/1")
+            layer = hub.KerasLayer(model_url)
             self.assertEqual([1, 1], layer(test_inputs).shape)
+        # Delete the files that were created in KaggleJwtHandler's do_POST method
+        model_path = os.path.join(MOUNT_PATH, "foomodule/tensorflow2/barvar/2")
+        os.unlink(model_path)
+        os.rmdir(os.path.dirname(model_path))
 
     def test_kaggle_resolver_not_attached_throws(self):
         with create_test_server(KaggleJwtHandler) as addr:


### PR DESCRIPTION
This change is required to unblock https://github.com/Kaggle/kaggleazure/pull/28591, which updates the Kernel MT to only use short URLs. 

**Testing**
Added unit test and ran ./test