### PR TITLE
add optree

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -211,6 +211,8 @@ RUN pip install \
         git+https://github.com/tensorflow/probability.git@fbc5ebe9b1d343113fb917010096cfd88b32eecf \
         tensorflow_text \
         "tensorflow_hub>=0.16.0" \
+        # b/331799280 remove once other packages over to dm-tre
+        optree \
         tf-keras && \
     /tmp/clean-layer.sh
 


### PR DESCRIPTION
keras 3.11.something moved from optree to dm-tre. other keras-related packages still need optree

add package, tested locally seems to pass smoke test. 

cc: @lucyhe 