### PR TITLE
fix datasets

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -525,7 +525,6 @@ RUN pip install flashtext \
         pyemd \
         pyupset \
         pympler \
-        s3fs \
         featuretools \
         #-e git+https://github.com/SohierDane/BigQuery_Helper#egg=bq_helper \
         git+https://github.com/Kaggle/learntools \
@@ -561,8 +560,9 @@ RUN pip install pytorch-ignite \
         bqplot \
         earthengine-api \
         transformers \
-        # b/232247930 >= 2.2.0 requires pyarrow >= 6.0.0 which conflicts with dependencies for rapidsai 0.21.*
-        datasets==2.1.0 \
+        datasets \
+        s3fs \
+        gcsfs \
         kaggle-environments \
         geopandas \
         "shapely<2" \

--- a/tests/test_hf_datasets.py
+++ b/tests/test_hf_datasets.py
@@ -1,7 +1,8 @@
 import unittest
 
-from datasets import Dataset
-
+import datasets
+import pandas as pd
+import warnings
 
 class TestHuggingFaceDatasets(unittest.TestCase):
 
@@ -10,7 +11,13 @@ class TestHuggingFaceDatasets(unittest.TestCase):
             batch['label'] = 'foo'
             return batch
             
-        df = Dataset.from_dict({'text': ['Kaggle rocks!']})
+        df = datasets.Dataset.from_dict({'text': ['Kaggle rocks!']})
         mapped_df = df.map(some_func)
         
         self.assertEqual('foo', mapped_df[0]['label'])
+        
+    def test_load_dataset(self):
+        warnings.simplefilter(action='ignore', category=FutureWarning)
+        dataset = datasets.load_dataset("csv", data_files="/input/tests/data/train.csv")
+        full_data = pd.DataFrame(dataset['train'])
+        self.assertFalse(full_data.empty)

--- a/tests/test_hf_datasets.py
+++ b/tests/test_hf_datasets.py
@@ -2,7 +2,6 @@ import unittest
 
 import datasets
 import pandas as pd
-import warnings
 
 class TestHuggingFaceDatasets(unittest.TestCase):
 
@@ -17,7 +16,6 @@ class TestHuggingFaceDatasets(unittest.TestCase):
         self.assertEqual('foo', mapped_df[0]['label'])
         
     def test_load_dataset(self):
-        warnings.simplefilter(action='ignore', category=FutureWarning)
         dataset = datasets.load_dataset("csv", data_files="/input/tests/data/train.csv")
         full_data = pd.DataFrame(dataset['train'])
         self.assertFalse(full_data.empty)


### PR DESCRIPTION
unpin datasets, looks like an attempt was made to do this in past but failed due to tfjs

but we don't install that package anymore. so let's unpin it since breaking due to package conflicts
moved s3fs to get a compatible version with fsspec. directly installed gcsfs, this is indirectly installed by another package but complains about fsspec version. installing directly seems to do the trick.

manually tested load_dataset function, works! 

https://github.com/Kaggle/docker-python/pull/1343
b/232247930