### PR TITLE
Fix LSP by pinning jupyter_server.

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -619,8 +619,8 @@ RUN pip install --upgrade dask && \
     mkdir -p /etc/ipython/ && echo "c = get_config(); c.IPKernelApp.matplotlib = 'inline'" > /etc/ipython/ipython_config.py && \
     # Temporary patch for broken libpixman 0.38 in conda-forge, symlink to system libpixman 0.34 untile conda package gets updated to 0.38.5 or higher.
     ln -sf /usr/lib/x86_64-linux-gnu/libpixman-1.so.0.34.0 /opt/conda/lib/libpixman-1.so.0.38.0 && \
-    # upgrade jupyter-server to version > 2.x
-    pip install --force-reinstall --no-deps jupyter_server>=2.* && \
+    # pin jupyter-server to version 2.12.5; later versions break LSP (b/333854354)
+    pip install --force-reinstall --no-deps jupyter_server==2.12.5 && \
     /tmp/clean-layer.sh
 
 # Fix to import bq_helper library without downgrading setuptools


### PR DESCRIPTION
LSP was broken in the release on 2024-03-20 by an automatic upgrade of jupyter_server from 2.12.5 to 2.13.0. Pinning this for now to resolve that issue.

http://b/333854354