### PR TITLE
Bump PyTorch version to 2.3

### DIFF
--- a/tpu/config.txt
+++ b/tpu/config.txt
@@ -9,11 +9,11 @@ TF_LINUX_WHEEL_VERSION=manylinux_2_17_x86_64.manylinux2014_x86_64
 JAX_VERSION=0.4.23
 # gsutil ls gs://pytorch-xla-releases/wheels/tpuvm/* | grep libtpu | grep -v -E ".*rc[0-9].*"
 # Supports nightly
-TORCH_VERSION=2.2.0
+TORCH_VERSION=2.3.0
 # https://github.com/pytorch/audio supports nightly
-TORCHAUDIO_VERSION=2.2.1
+TORCHAUDIO_VERSION=2.3.0
 # https://github.com/pytorch/text supports main
-TORCHTEXT_VERSION=0.17.1
+TORCHTEXT_VERSION=0.18.0
 # https://github.com/pytorch/vision supports nightly
-TORCHVISION_VERSION=0.17.1
+TORCHVISION_VERSION=0.18.0
 TORCH_LINUX_WHEEL_VERSION=manylinux_2_28_x86_64


### PR DESCRIPTION
Also bump ecosystem packages (torchtext, torchvision, torchaudio) to latest versions

cc @will-cromar 