### PR TITLE
Stop auto-promoting TPU image to staging tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,7 +238,7 @@ pipeline {
 
           gcloud container images add-tag gcr.io/kaggle-images/python:${PRETEST_TAG} gcr.io/kaggle-images/python:${STAGING_TAG}
           gcloud container images add-tag gcr.io/kaggle-private-byod/python:${PRETEST_TAG} gcr.io/kaggle-private-byod/python:${STAGING_TAG}
-          gcloud container images add-tag gcr.io/kaggle-private-byod/python-tpuvm:${PRETEST_TAG} gcr.io/kaggle-private-byod/python-tpuvm:${STAGING_TAG}
+          // NOTE(b/336842777): TPUVM images are tested on an actual TPU VM outside this pipeline, so they are not auto-promoted to :staging tag.
         '''
       }
     }


### PR DESCRIPTION
There are no tests for the TPU image so promoting from :ci-pretest to :staging incorrectly makes it sound like the image is ready for the next stage of tests. Instead we'll leave it at :ci-pretest and have a separate process test and promote them.

http://b/336842777