### PR TITLE
Pin keras nlp

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -229,6 +229,7 @@ ADD patches/keras_internal_test.py /opt/conda/lib/python3.10/site-packages/tenso
 # Remove "--no-deps" flag and "namex" package once Keras 3.* is included in our base image.
 # We ignore dependencies since tf2.15 and Keras 3.* should work despite pip saying it won't.
 # Currently, keras tries to install a nightly version of tf 2.16: https://github.com/keras-team/keras/blob/fe2f54aa5bc42fb23a96449cf90434ab9bb6a2cd/requirements.txt#L2
+# b/341360061 Unpin keras-nlp once kaggle-hub is able to provide task.json file when requested
 RUN pip install --no-deps "keras>3" keras-cv "keras-nlp==0.9.3" namex && \
     /tmp/clean-layer.sh
 

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -229,7 +229,7 @@ ADD patches/keras_internal_test.py /opt/conda/lib/python3.10/site-packages/tenso
 # Remove "--no-deps" flag and "namex" package once Keras 3.* is included in our base image.
 # We ignore dependencies since tf2.15 and Keras 3.* should work despite pip saying it won't.
 # Currently, keras tries to install a nightly version of tf 2.16: https://github.com/keras-team/keras/blob/fe2f54aa5bc42fb23a96449cf90434ab9bb6a2cd/requirements.txt#L2
-RUN pip install --no-deps "keras>3" keras-cv keras-nlp namex && \
+RUN pip install --no-deps "keras>3" keras-cv "keras-nlp==0.9.3" namex && \
     /tmp/clean-layer.sh
 
 # b/328788268 libpysal 4.10 seems to fail with "module 'shapely' has no attribute 'Geometry'. Did you mean: 'geometry'"


### PR DESCRIPTION
looks like newer version of keras-nlp (>0.9.3) starts requesting "task.json" files when downloading models from kaggle-hub, which we don't provide afaik: https://screenshot.googleplex.com/BQpNeHjdS6yPnrm

which causes the docker keras-nlp test to fail (added logs):
https://paste.googleplex.com/4613448323563520

let's pin to unblock pipeline, reachout to models/kaggle hub poc about issue

https://b.corp.google.com/issues/341360061