### PR TITLE
Update Kagglehub mock and unpin keras-nlp

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -224,7 +224,7 @@ ADD patches/keras_internal_test.py /opt/conda/lib/python3.10/site-packages/tenso
 # We ignore dependencies since tf2.15 and Keras 3.* should work despite pip saying it won't.
 # Currently, keras tries to install a nightly version of tf 2.16: https://github.com/keras-team/keras/blob/fe2f54aa5bc42fb23a96449cf90434ab9bb6a2cd/requirements.txt#L2
 # b/341360061 Unpin keras-nlp once kaggle-hub is able to provide task.json file when requested
-RUN pip install --no-deps "keras>3" keras-cv "keras-nlp==0.9.3" namex && \
+RUN pip install --no-deps "keras>3" keras-cv keras-nlp namex && \
     /tmp/clean-layer.sh
 
 # b/328788268 libpysal 4.10 seems to fail with "module 'shapely' has no attribute 'Geometry'. Did you mean: 'geometry'"

--- a/tests/utils/kagglehub.py
+++ b/tests/utils/kagglehub.py
@@ -26,8 +26,10 @@ class KaggleAPIHandler(BaseHTTPRequestHandler):
         path = m.group(2)
         filepath = f"/input/tests/data/kagglehub/models/{model_handle}/{path}"
         if not os.path.isfile(filepath):
-            self.send_response(404)
-            self.end_headers()
+            self.send_error(404, "Internet is disabled in our tests "
+                "kagglehub uses a fake API server "
+                f"Use `kagglehub.model_download('{model_handle}', path='{path}')` to download the missing file "
+                f"and copy it to `./docker-python/tests/data/kagglehub/models/{model_handle}/{path}`.")
             return
 
         with open(filepath, "rb") as f:

--- a/tests/utils/kagglehub.py
+++ b/tests/utils/kagglehub.py
@@ -27,7 +27,7 @@ class KaggleAPIHandler(BaseHTTPRequestHandler):
         filepath = f"/input/tests/data/kagglehub/models/{model_handle}/{path}"
         if not os.path.isfile(filepath):
             self.send_error(404, "Internet is disabled in our tests "
-                "kagglehub uses a fake API server "
+                "kagglehub uses a fake API server. "
                 f"Use `kagglehub.model_download('{model_handle}', path='{path}')` to download the missing file "
                 f"and copy it to `./docker-python/tests/data/kagglehub/models/{model_handle}/{path}`.")
             return

--- a/tests/utils/kagglehub.py
+++ b/tests/utils/kagglehub.py
@@ -26,14 +26,10 @@ class KaggleAPIHandler(BaseHTTPRequestHandler):
         path = m.group(2)
         filepath = f"/input/tests/data/kagglehub/models/{model_handle}/{path}"
         if not os.path.isfile(filepath):
-            raise ValueError((
-                "Internet is disabled in our tests\n"
-                "kagglehub uses a fake API server\n"
-                f"Use `kagglehub.model_download('{model_handle}', path='{path}')` to download the missing file\n"
-                f"and copy it to `./docker-python/tests/data/kagglehub/models/{model_handle}/{path}`\n"
-            ))
+            self.send_response(404)
+            self.end_headers()
             return
-        
+
         with open(filepath, "rb") as f:
             self.send_response(200)
             self.send_header("Content-type", "application/octet-stream")


### PR DESCRIPTION
wrongly pinned keras-nlp, let's unpinned it. update mock to support optional files.

https://b.corp.google.com/issues/341982731