### PR TITLE
Remove "Rubbish" files in Root dir

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -266,9 +266,9 @@ RUN pip install opencv-contrib-python opencv-python && \
     /tmp/clean-layer.sh
 
 # Pin scipy until we update JAX b/335003097
-RUN pip install scipy==1.12.0 \
+RUN pip install "scipy==1.12.0" \
         # Scikit-learn accelerated library for x86
-        scikit-learn-intelex>=2023.0.1 \
+        "scikit-learn-intelex>=2023.0.1" \
         # HDF5 support
         h5py \
         # PUDB, for local debugging convenience


### PR DESCRIPTION
Seems like we get files containing pip output, unlikely that these are important. adding " " removes the file, which is convention syntax.

before:
https://screenshot.googleplex.com/9iVBh5Mtprsc95u

after: 
https://screenshot.googleplex.com/C6Kzxj8d8PqpCCS

fixes
https://github.com/Kaggle/docker-python/issues/1249