### PR TITLE
Remove duplicate aiohttp

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -572,7 +572,7 @@ RUN pip install pytorch-ignite \
         pip install git+https://github.com/facebookresearch/segment-anything.git && \
     # b/343971718: remove duplicate aiohttp installs, and reinstall it
     rm -rf /opt/conda/lib/python3.10/site-packages/aiohttp* && \
-    pip install aiohttp && \
+    mamba install --force-reinstall -y aiohttp && \
     /tmp/clean-layer.sh
 
 # Download base easyocr models.

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -424,10 +424,7 @@ RUN pip install annoy \
 
 # b/273059949 The pre-installed nbconvert is slow on html conversions and has to be force-uninstalled.
 # b/274619697 learntools also requires a specific nbconvert right now
-RUN rm -rf /opt/conda/lib/python3.10/site-packages/nbconvert*
-RUN rm -rf /opt/conda/lib/python3.10/site-packages/nbclient*
-RUN rm -rf /opt/conda/lib/python3.10/site-packages/mistune*
-RUN rm -rf /opt/conda/lib/python3.10/site-packages/platformdirs*
+RUN rm -rf /opt/conda/lib/python3.10/site-packages/{nbconvert,nbclient,mistune,platformdirs}*
 
 # Fix qgrid by pinning ipywidgets https://github.com/quantopian/qgrid/issues/376
 #        allennlp \
@@ -573,6 +570,9 @@ RUN pip install pytorch-ignite \
         timm \
         torchinfo && \
         pip install git+https://github.com/facebookresearch/segment-anything.git && \
+    # b/343971718: remove duplicate aiohttp installs, and reinstall it
+    rm -rf /opt/conda/lib/python3.10/site-packages/aiohttp* && \
+    pip install aiohttp && \
     /tmp/clean-layer.sh
 
 # Download base easyocr models.


### PR DESCRIPTION
We seem to be downloading multiple aiohttp version, we which is causing pip error out when installing some packages. we will remove and install again. 

added small refactor

proof of concept:
https://screencast.googleplex.com/cast/NDkzOTIxMTcwNTY3OTg3Mnw2Zjc5MjBkYy0wYg