### PR TITLE
Extend TORCH_CUDA_ARCH_LIST to support additional CUDA architectures, including sm_80, sm_86, sm_87, sm_89, and sm_90

### DIFF
--- a/packages/torch.Dockerfile
+++ b/packages/torch.Dockerfile
@@ -31,7 +31,7 @@ ENV PYTORCH_BUILD_NUMBER=1
 # For PyTorch, we need specifically mkl.
 ENV LIBRARY_PATH="$LIBRARY_PATH:/opt/conda/lib"
 ENV LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/conda/lib"
-ENV TORCH_CUDA_ARCH_LIST="6.0;7.0+PTX;7.5+PTX"
+ENV TORCH_CUDA_ARCH_LIST="6.0;7.0;7.5;8.0;8.6;8.7;8.9;9.0+PTX"
 ENV FORCE_CUDA=1
 RUN cd /usr/local/src && \
     git clone --recursive https://github.com/pytorch/pytorch && \


### PR DESCRIPTION
**Current Build Support:**
- **Pascal (GeForce 10 series, P100)**
- **Turing (GeForce 20 series, V100)**
- Supported CUDA capabilities: `sm_60`, `sm_70`, `sm_75`, `compute_70`, `compute_75`.

**Issue:**
On newer CUDA architectures, starting from **Ampere (GeForce 30 series, A100)**, there is a warning message when PyTorch with CUDA (GPU) is being used:

```
/opt/conda/lib/python3.10/site-packages/torch/cuda/__init__.py:215: UserWarning: 
NVIDIA GeForce RTX 3070 Laptop GPU with CUDA capability sm_86 is not compatible with the current PyTorch installation.
The current PyTorch install supports CUDA capabilities sm_60 sm_70 sm_75 compute_70 compute_75.
```

For some tasks, this leads to FATAL ERRORs and makes GPU utilization impossible:
```
FATAL: kernel `fmha_cutlassF_f32_aligned_64x64_rf_sm80` is for sm80-sm100, but was built for sm75
```

**Objective of this Pull Request:**
This Pull Request aims to address the compatibility issues and extend support for all architectures up to **Ampere (GeForce 40 series, H100)**.