### PR TITLE
Fix Kagglehub test and Remove multiple version matplotlib files

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -167,27 +167,10 @@ RUN pip install jax[cpu] && \
 RUN export PATH=/usr/local/cuda/bin:$PATH && \
     export CUDA_ROOT=/usr/local/cuda && \
     pip install pycuda \
-        pynvrtc \
+        pynvrtc==9.2\
         pynvml && \
     /tmp/clean-layer.sh
 {{ end }}
-
-# b/308525631: Pin Matplotlib until seaborn can be upgraded
-# to >0.13.0 (now it's stuck by a package conflict with ydata-profiling 4.5.1).
-RUN JAXVER=$(pip freeze | grep -e "^jax==") && \
-    pip install --upgrade \
-        "matplotlib<3.8.0" \
-        # ipympl adds interactive widget support for matplotlib
-        ipympl==0.7.0 \
-        "seaborn==0.12.2" \
-        pyupset \
-        python-dateutil dask dask-expr igraph \
-        pyyaml joblib geopy mne pyshp \
-        pandas \
-        polars \
-        flax \
-        "${JAXVER}" && \
-    /tmp/clean-layer.sh
 
 RUN apt-get update && \
     apt-get install -y default-jre && \
@@ -542,6 +525,23 @@ ENV TESSERACT_PATH=/usr/bin/tesseract \
     PYTHONPATH=$PYTHONPATH:/opt/facets/facets_overview/python/ \
     # For Theano with MKL
     MKL_THREADING_LAYER=GNU
+
+# b/308525631: Pin Matplotlib until seaborn can be upgraded
+# to >0.13.0 (now it's stuck by a package conflict with ydata-profiling 4.5.1).
+RUN JAXVER=$(pip freeze | grep -e "^jax==") && \
+pip install --upgrade \
+    "matplotlib<3.8.0" \
+    # ipympl adds interactive widget support for matplotlib
+    ipympl==0.7.0 \
+    "seaborn==0.12.2" \
+    pyupset \
+    python-dateutil dask dask-expr igraph \
+    pyyaml joblib geopy mne pyshp \
+    pandas \
+    polars \
+    flax \
+    "${JAXVER}" && \
+/tmp/clean-layer.sh
 
 # Temporary fixes and patches
 # Temporary patch for Dask getting downgraded, which breaks Keras

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -173,6 +173,24 @@ RUN export PATH=/usr/local/cuda/bin:$PATH && \
     /tmp/clean-layer.sh
 {{ end }}
 
+
+# b/308525631: Pin Matplotlib until seaborn can be upgraded
+# to >0.13.0 (now it's stuck by a package conflict with ydata-profiling 4.5.1).
+RUN JAXVER=$(pip freeze | grep -e "^jax==") && \
+pip install --upgrade \
+    "matplotlib<3.8.0" \
+    # ipympl adds interactive widget support for matplotlib
+    ipympl==0.7.0 \
+    "seaborn==0.12.2" \
+    pyupset \
+    python-dateutil dask dask-expr igraph \
+    pyyaml joblib geopy mne pyshp \
+    pandas \
+    polars \
+    flax \
+    "${JAXVER}" && \
+/tmp/clean-layer.sh
+
 RUN apt-get update && \
     apt-get install -y default-jre && \
     /tmp/clean-layer.sh
@@ -527,26 +545,10 @@ ENV TESSERACT_PATH=/usr/bin/tesseract \
     # For Theano with MKL
     MKL_THREADING_LAYER=GNU
 
-# b/308525631: Pin Matplotlib until seaborn can be upgraded
-# to >0.13.0 (now it's stuck by a package conflict with ydata-profiling 4.5.1).
-RUN JAXVER=$(pip freeze | grep -e "^jax==") && \
-pip install --upgrade \
-    "matplotlib<3.8.0" \
-    # ipympl adds interactive widget support for matplotlib
-    ipympl==0.7.0 \
-    "seaborn==0.12.2" \
-    pyupset \
-    python-dateutil dask dask-expr igraph \
-    pyyaml joblib geopy mne pyshp \
-    pandas \
-    polars \
-    flax \
-    "${JAXVER}" && \
-/tmp/clean-layer.sh
-
 # Temporary fixes and patches
 # Temporary patch for Dask getting downgraded, which breaks Keras
 RUN pip install --upgrade dask && \
+    pip install "matplotlib<3.8.0" && \
     # Stop jupyter nbconvert trying to rewrite its folder hierarchy
     mkdir -p /root/.jupyter && touch /root/.jupyter/jupyter_nbconvert_config.py && touch /root/.jupyter/migrated && \
     mkdir -p /.jupyter && touch /.jupyter/jupyter_nbconvert_config.py && touch /.jupyter/migrated && \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -173,24 +173,6 @@ RUN export PATH=/usr/local/cuda/bin:$PATH && \
     /tmp/clean-layer.sh
 {{ end }}
 
-
-# b/308525631: Pin Matplotlib until seaborn can be upgraded
-# to >0.13.0 (now it's stuck by a package conflict with ydata-profiling 4.5.1).
-RUN JAXVER=$(pip freeze | grep -e "^jax==") && \
-    pip install --upgrade \
-        "matplotlib<3.8.0" \
-        # ipympl adds interactive widget support for matplotlib
-        ipympl==0.7.0 \
-        "seaborn==0.12.2" \
-        pyupset \
-        python-dateutil dask dask-expr igraph \
-        pyyaml joblib geopy mne pyshp \
-        pandas \
-        polars \
-        flax \
-        "${JAXVER}" && \
-    /tmp/clean-layer.sh
-
 RUN apt-get update && \
     apt-get install -y default-jre && \
     /tmp/clean-layer.sh
@@ -482,7 +464,6 @@ RUN pip install wandb \
     rm -rf /opt/conda/lib/python3.10/site-packages/numpy* && \
     pip install "numpy==1.26.4" && \
     pip install pytorch-ignite \
-        "matplotlib==3.7.5"\
         qgrid \
         bqplot \
         earthengine-api \
@@ -496,7 +477,7 @@ RUN pip install wandb \
         "shapely<2" \
         pydub \
         pydegensac \
-        "torchmetrics==1.5.1" \
+        torchmetrics \
         pytorch-lightning \
         sympy \
         # flask is used by agents in the simulation competitions.
@@ -546,11 +527,30 @@ ENV TESSERACT_PATH=/usr/bin/tesseract \
     # For Theano with MKL
     MKL_THREADING_LAYER=GNU
 
+# b/308525631: Pin Matplotlib until seaborn can be upgraded
+# to >0.13.0 (now it's stuck by a package conflict with ydata-profiling 4.5.1).
+RUN JAXVER=$(pip freeze | grep -e "^jax==") && \
+    pip install --upgrade \
+        "matplotlib==3.7.5" \
+        # ipympl adds interactive widget support for matplotlib
+        ipympl==0.7.0 \
+        "seaborn==0.12.2" \
+        pyupset \
+        python-dateutil dask dask-expr igraph \
+        pyyaml joblib geopy mne pyshp \
+        pandas \
+        polars \
+        flax \
+        "${JAXVER}" && \
+    /tmp/clean-layer.sh
+
 # Temporary fixes and patches
 # Temporary patch for Dask getting downgraded, which breaks Keras
 RUN pip install --upgrade dask && \
     # Stop jupyter nbconvert trying to rewrite its folder hierarchy
     mkdir -p /root/.jupyter && touch /root/.jupyter/jupyter_nbconvert_config.py && touch /root/.jupyter/migrated && \
+    # TODO(b/380921973): Ensure only matplotlib 3.7.5 files are present.
+    rm -r /opt/conda/lib/python3.10/site-packages/matplotlib-3.9.2.dist-info/ && \
     mkdir -p /.jupyter && touch /.jupyter/jupyter_nbconvert_config.py && touch /.jupyter/migrated && \
     # Stop Matplotlib printing junk to the console on first load
     sed -i "s/^.*Matplotlib is building the font cache using fc-list.*$/# Warning removed by Kaggle/g" /opt/conda/lib/python3.10/site-packages/matplotlib/font_manager.py && \

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -496,7 +496,7 @@ RUN pip install wandb \
         "shapely<2" \
         pydub \
         pydegensac \
-        torchmetrics \
+        "torchmetrics==1.5.1" \
         pytorch-lightning \
         sympy \
         # flask is used by agents in the simulation competitions.

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -167,7 +167,8 @@ RUN pip install jax[cpu] && \
 RUN export PATH=/usr/local/cuda/bin:$PATH && \
     export CUDA_ROOT=/usr/local/cuda && \
     pip install pycuda \
-        pynvrtc==9.2\
+        # TODO(379932879): pip resolver fails when not specified.
+        pynvrtc==9.2 \
         pynvml && \
     /tmp/clean-layer.sh
 {{ end }}

--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -177,19 +177,19 @@ RUN export PATH=/usr/local/cuda/bin:$PATH && \
 # b/308525631: Pin Matplotlib until seaborn can be upgraded
 # to >0.13.0 (now it's stuck by a package conflict with ydata-profiling 4.5.1).
 RUN JAXVER=$(pip freeze | grep -e "^jax==") && \
-pip install --upgrade \
-    "matplotlib<3.8.0" \
-    # ipympl adds interactive widget support for matplotlib
-    ipympl==0.7.0 \
-    "seaborn==0.12.2" \
-    pyupset \
-    python-dateutil dask dask-expr igraph \
-    pyyaml joblib geopy mne pyshp \
-    pandas \
-    polars \
-    flax \
-    "${JAXVER}" && \
-/tmp/clean-layer.sh
+    pip install --upgrade \
+        "matplotlib<3.8.0" \
+        # ipympl adds interactive widget support for matplotlib
+        ipympl==0.7.0 \
+        "seaborn==0.12.2" \
+        pyupset \
+        python-dateutil dask dask-expr igraph \
+        pyyaml joblib geopy mne pyshp \
+        pandas \
+        polars \
+        flax \
+        "${JAXVER}" && \
+    /tmp/clean-layer.sh
 
 RUN apt-get update && \
     apt-get install -y default-jre && \
@@ -482,6 +482,7 @@ RUN pip install wandb \
     rm -rf /opt/conda/lib/python3.10/site-packages/numpy* && \
     pip install "numpy==1.26.4" && \
     pip install pytorch-ignite \
+        "matplotlib==3.7.5"\
         qgrid \
         bqplot \
         earthengine-api \
@@ -548,7 +549,6 @@ ENV TESSERACT_PATH=/usr/bin/tesseract \
 # Temporary fixes and patches
 # Temporary patch for Dask getting downgraded, which breaks Keras
 RUN pip install --upgrade dask && \
-    pip install "matplotlib<3.8.0" && \
     # Stop jupyter nbconvert trying to rewrite its folder hierarchy
     mkdir -p /root/.jupyter && touch /root/.jupyter/jupyter_nbconvert_config.py && touch /root/.jupyter/migrated && \
     mkdir -p /.jupyter && touch /.jupyter/jupyter_nbconvert_config.py && touch /.jupyter/migrated && \

--- a/tests/test_kagglehub.py
+++ b/tests/test_kagglehub.py
@@ -8,8 +8,10 @@ class TestKagglehub(unittest.TestCase):
     def test_login(self):
         with self.assertLogs('kagglehub', level='INFO') as l:
             with mock.patch("builtins.input") as mock_input:
-                mock_input.side_effect = ["lastplacelarry", "some-key"]
-                # Disabling credentials validation since network access is disabled in unittest.
-                kagglehub.login(validate_credentials=False)
+                with mock.patch("getpass.getpass") as mock_getpass:
+                    mock_input.side_effect = ["lastplacelarry"]
+                    mock_getpass.return_value = "some-key"
 
-                self.assertIn("credentials set", l.output[0])
+                    kagglehub.login(validate_credentials=False)
+
+                    self.assertIn("credentials set", l.output[0])


### PR DESCRIPTION
fixing main build.
- kagglehub login changes required updating our tests
- latest matplotlib is needed by handful of package, but breaks learntools. i provided a workaround