### PR TITLE
Split build and test parallel steps

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline {
               }
             }
             stage('Test GPU Image') {
-              stages {
+              parallel {
                 stage('Test on P100') {
                   agent { label 'ephemeral-linux-gpu' }
                   options {


### PR DESCRIPTION
This speeds up e2e pipeline time since all three builds take around 10-11m now and tests take about 5m, making those two phases faster.