### PR TITLE
Try to make tf 2.18 on tpu vm install reliably

### DIFF
--- a/tpu/Dockerfile
+++ b/tpu/Dockerfile
@@ -69,7 +69,7 @@ ENV PATH="~/.local/bin:${PATH}"
 # Try to force tensorflow to reliably install without breaking other installed deps
 RUN export PATH="${HOME}/.local/bin:${PATH}" && \
     uv pip freeze --system > /tmp/constraints.txt && \
-    uv pip install --system -c /tmp/constraints.txt tensorflow-tpu -f https://storage.googleapis.com/libtpu-tf-releases/index.html && \
+    uv pip install --system -c /tmp/constraints.txt tensorflow-tpu -f https://storage.googleapis.com/libtpu-tf-releases/index.html --force-reinstall && \
     rm /tmp/constraints.txt
 
 # Kaggle Model Hub patches:

--- a/tpu/Dockerfile
+++ b/tpu/Dockerfile
@@ -66,6 +66,12 @@ RUN export PATH="${HOME}/.local/bin:${PATH}" && uv pip install --system -r /requ
     /tmp/clean-layer.sh
 ENV PATH="~/.local/bin:${PATH}"
 
+# Try to force tensorflow to reliably install without breaking other installed deps
+RUN export PATH="${HOME}/.local/bin:${PATH}" && \
+    uv pip freeze --system > /tmp/constraints.txt && \
+    uv pip install --system -c /tmp/constraints.txt tensorflow-tpu -f https://storage.googleapis.com/libtpu-tf-releases/index.html && \
+    rm /tmp/constraints.txt
+
 # Kaggle Model Hub patches:
 ADD patches/kaggle_module_resolver.py /usr/local/lib/${PYTHON_VERSION_PATH}/site-packages/tensorflow_hub/kaggle_module_resolver.py
 RUN sed -i '/from tensorflow_hub import uncompressed_module_resolver/a from tensorflow_hub import kaggle_module_resolver' /usr/local/lib/${PYTHON_VERSION_PATH}/site-packages/tensorflow_hub/config.py


### PR DESCRIPTION
I'm seeing it randomly pick the CUDA enabled version for some reason.
Trying a force reinstall while maintaining existing packages to see if that helps.