### PR TITLE
Fix kagglehub 

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -28,6 +28,9 @@ ENV PATH="~/.local/bin:${PATH}"
 # b/183041606#comment5: the Kaggle data proxy doesn't support these APIs. If the library is missing, it falls back to using a regular BigQuery query to fetch data.
 RUN uv pip uninstall --system google-cloud-bigquery-storage
 
+# b/394382016: sigstore (dependency of kagglehub) requires a prerelease packages, installing separate.
+RUN uv pip install --system --force-reinstall --prerelease=allow kagglehub[pandas-datasets,hf-datasets]>=0.3.7
+
 # uv cannot install this in requirements.txt without --no-build-isolation
 # to avoid affecting the larger build, we'll post-install it.
 RUN uv pip install --no-build-isolation --system "git+https://github.com/Kaggle/learntools"

--- a/kaggle_requirements.txt
+++ b/kaggle_requirements.txt
@@ -70,7 +70,6 @@ jupyter_server==2.12.5
 jupyterlab
 jupyterlab-lsp
 kaggle-environments
-kagglehub[pandas-datasets,hf-datasets]>=0.3.6
 # Keras 3.6 broke test_keras.py > test_train > keras.datasets.mnist.load_data():
 # See https://github.com/keras-team/keras/commit/dcefb139863505d166dd1325066f329b3033d45a
 keras<3.6


### PR DESCRIPTION
UV requires a separate flag for allowing prerelease packages to be installed.

kagglehub install fails due to this, since sigstore (a dependency) needs a prerelease package.
let's install it separate to allow prerelease installs.

 https://b.corp.google.com/issues/394382016