### PR TITLE
Adjust pins to fix learn tools tests errors 

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -45,9 +45,11 @@ RUN uv pip install --no-build-isolation --system "git+https://github.com/Kaggle/
 
 # b/408281617: Torch is adamant that it can not install cudnn 9.3.x, only 9.1.x, but Tensorflow can only support 9.3.x.
 # This conflict causes a number of package downgrades, which are handled in this command
-RUN uv pip install --system --force-reinstall --extra-index-url https://pypi.nvidia.com pynvjitlink-cu12 cuml-cu12==25.2.1 \
-    nvidia-cudnn-cu12==9.3.0.75 scipy tsfresh
-RUN uv pip install --system --force-reinstall pynvjitlink-cu12==0.5.2
+# b/302136621: Fix eli5 import for learntools
+RUN uv pip install --system --force-reinstall --extra-index-url https://pypi.nvidia.com "cuml-cu12==25.2.1" \
+    "nvidia-cudnn-cu12==9.3.0.75" scipy tsfresh scikit-learn==1.2.2 category-encoders eli5
+
+RUN uv pip install --system --force-reinstall "pynvjitlink-cu12==0.5.2"
 
 # b/385145217 Latest Colab lacks mkl numpy, install it.
 RUN uv pip install --system --force-reinstall -i https://pypi.anaconda.org/intel/simple numpy

--- a/kaggle_requirements.txt
+++ b/kaggle_requirements.txt
@@ -20,7 +20,6 @@ arrow
 bayesian-optimization
 boto3
 catboost
-category-encoders
 cesium
 comm
 cytoolz
@@ -33,7 +32,6 @@ deap
 dipy
 docker
 easyocr
-eli5
 emoji
 fastcore>=1.7.20
 fasttext
@@ -111,8 +109,6 @@ qtconsole
 ray
 rgf-python
 s3fs
- # b/302136621: Fix eli5 import for learntools
-scikit-learn==1.2.2
 # Scikit-learn accelerated library for x86
 scikit-learn-intelex>=2023.0.1
 scikit-multilearn


### PR DESCRIPTION
Torch and Cuml have compatibility issues, installing them outside of requirements files removes some of our pins. Let's add them back in when installing to ensure that pins are in place.