### PR TITLE
Add anywidget

### DIFF
--- a/kaggle_requirements.txt
+++ b/kaggle_requirements.txt
@@ -16,6 +16,7 @@ TPOT==0.12.1
 Theano
 Wand
 annoy
+anywidget
 arrow
 bayesian-optimization
 boto3

--- a/tests/test_anywidget.py
+++ b/tests/test_anywidget.py
@@ -12,6 +12,7 @@ def strip_ansi(text):
 class TestAnyWidget(unittest.TestCase):
 
     def test_labextension(self):
+        """Test if the anywidget labextension is installed and enabled."""
         output = subprocess.check_output(
             ["jupyter", "labextension", "list"], stderr=subprocess.STDOUT, text=True
         )

--- a/tests/test_anywidget.py
+++ b/tests/test_anywidget.py
@@ -1,0 +1,20 @@
+import unittest
+import subprocess
+import re
+
+
+# Remove ANSI coloring escape codes
+def strip_ansi(text):
+    ansi_escape = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
+    return ansi_escape.sub("", text)
+
+
+class TestAnyWidget(unittest.TestCase):
+
+    def test_labextension(self):
+        output = subprocess.check_output(
+            ["jupyter", "labextension", "list"], stderr=subprocess.STDOUT, text=True
+        )
+        output = strip_ansi(output)
+        match = re.search(r"^\s*anywidget\s+v[\d.]+\s+enabled.*$", output, re.MULTILINE)
+        self.assertIsNotNone(match, "anywidget not found in labextension list")

--- a/tests/test_anywidget.py
+++ b/tests/test_anywidget.py
@@ -16,5 +16,5 @@ class TestAnyWidget(unittest.TestCase):
             ["jupyter", "labextension", "list"], stderr=subprocess.STDOUT, text=True
         )
         output = strip_ansi(output)
-        match = re.search(r"^\s*anywidget\s+v[\d.]+\s+enabled.*$", output, re.MULTILINE)
+        match = re.search(r"^\s*anywidget\s+v[\d.]+\s+enabled\s+OK\b.*$", output, re.MULTILINE)
         self.assertIsNotNone(match, "anywidget not found in labextension list")


### PR DESCRIPTION
This adds anywidget, which is basically a custom ipywidget that allows the creation of other custom widgets without the need to install additional Jupyter extensions. According to the [website](https://anywidget.dev/en/getting-started/#relationship-to-jupyter-widgets), it's now the recommended method for creating Jupyter widgets.

Installing simply via `!pip install anywidget` does not work as registering the labextension (JS parts) requires a restart. On Colab `pip install` does work, however they have a special method of retrieving the necessary JS from a CDN.

Installing via the Kaggle package manager does work, however this seems to be only available for competition notebooks.