### PR TITLE
Bump Colab Base Image - July

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -1,4 +1,4 @@
 BASE_IMAGE=us-docker.pkg.dev/colab-images/public/runtime
-BASE_IMAGE_TAG=release-colab_20250603-060055_RC00
+BASE_IMAGE_TAG=release-colab_20250626-060053_RC00
 CUDA_MAJOR_VERSION=12
 CUDA_MINOR_VERSION=5


### PR DESCRIPTION
let's bump the image, this was released a couple days ago. while we were planning a release with the prior Base image, let's save us a release and get our self to the latest