### PR TITLE
Fix kornia test failure

### DIFF
--- a/tests/test_kornia.py
+++ b/tests/test_kornia.py
@@ -7,7 +7,7 @@ import kornia
 class TestKornia(unittest.TestCase):
     def test_imread_opencv(self):
         img = cv2.imread('/input/tests/data/dot.png')
-        img_t = kornia.utils.image_to_tensor(img)
+        img_t = kornia.image.image_to_tensor(img)
 
         self.assertEqual(img.shape, (1, 1, 3))
         self.assertEqual(img_t.shape, (3, 1, 1))


### PR DESCRIPTION
kornia.utils.image_to_tensor is deprecated and not lazy loaded anymore. Using the new location instead.

http://b/515825952