### PR TITLE
Add kaggle-benchmarks to the main image.

### DIFF
--- a/Dockerfile.tmpl
+++ b/Dockerfile.tmpl
@@ -27,7 +27,7 @@ RUN uv pip install --no-build-isolation --no-cache --system "git+https://github.
 # b/404590350: Ray and torchtune have conflicting cli named `tune`. `ray` is not part of Colab's base image. Re-install `tune` to ensure the torchtune CLI is available by default.
 # b/468367647: Unpin protobuf, version greater than v5.29.5 causes issues with numerous packages
 RUN uv pip install --system --force-reinstall --no-cache --no-deps torchtune
-RUN uv pip install --system --force-reinstall --no-cache "protobuf==5.29.5"
+RUN uv pip install --system --force-reinstall --no-cache "protobuf==5.29.6"
 # b/493600019: Colab base image ships numba that does not support NumPy 2.4; upgrade to latest.
 RUN uv pip install --system --force-reinstall --no-cache numba
 

--- a/kaggle_requirements.txt
+++ b/kaggle_requirements.txt
@@ -59,6 +59,7 @@ jupyter_server_proxy
 jupyterlab
 jupyterlab-lsp
 kaggle>=1.8.3
+kaggle-benchmarks
 kaggle-environments
 kagglehub[pandas-datasets,hf-datasets,signing]>=0.4.2
 keras-cv

--- a/tests/test_kaggle_benchmarks.py
+++ b/tests/test_kaggle_benchmarks.py
@@ -1,0 +1,21 @@
+import unittest
+from packaging.version import parse
+import kaggle_benchmarks
+
+class TestKaggleBenchmarks(unittest.TestCase):
+    def test_version(self):
+        self.assertGreaterEqual(parse(kaggle_benchmarks.__version__), parse("0.6"))
+
+    def test_core_imports(self):
+        from kaggle_benchmarks import (
+            Actor,
+            ChatRoom,
+            ExecutionMode,
+            LLMChat,
+            Participant,
+            Run,
+            Runs,
+            Usage,
+            benchmark,
+            task,
+        )


### PR DESCRIPTION
Adds kaggle-benchmarks to our main image for some experiments. Relies on [https://github.com/Kaggle/kaggle-benchmarks/pull/175](https://github.com/Kaggle/kaggle-benchmarks/pull/175), which will allow us to install a slightly abbreviated version of kaggle-benchmarks that does not require the large playwright binaries.